### PR TITLE
Add the ability to specify the H-track position of a H-Tree.

### DIFF
--- a/crlcore/python/technos/symbolic/cmos/kite.py
+++ b/crlcore/python/technos/symbolic/cmos/kite.py
@@ -30,6 +30,8 @@ p = Cfg.getParamInt       ( "katabatic.globalLengthThreshold" ).setInt       ( 1
 p = Cfg.getParamPercentage( "katabatic.saturateRatio"         ).setPercentage( 80       ) 
 p = Cfg.getParamInt       ( "katabatic.saturateRp"            ).setInt       ( 8        )
 p = Cfg.getParamString    ( 'katabatic.topRoutingLayer'       ).setString    ( 'METAL5' )
+#p = Cfg.getParamInt       ( "spares.htreeOffsetDriver"        ).setInt       ( 4        )
+#p = Cfg.getParamInt       ( "spares.htreeOffsetSink"          ).setInt       ( 6        )
 
  # Kite parameters.
 p = Cfg.getParamInt( "kite.hTracksReservedLocal" ); p.setInt( 3       ); p.setMin( 0 ); p.setMax( 20 )


### PR DESCRIPTION
Formerly, the H-Track could be shifted *relative* to the position of the center of the RoutingPad. Which may become fragile in case of a change in the standard cell library. So we create a new feature allowing to specify the H-track as an offset *from the bottom of the slice*. Two offset can be specified:
  * spares.htreeOffsetDriver : for the main H part, connected to the driver.
  * spares.htreeOffsetSink : for the small parts connecting to every fours sinks of the tree. This to avoid those two to overlap. The sink of the "N" stage with the driver of the "N+1" stage (so input & ouput of the same buffer).