### PR TITLE
Only run test uploads on main

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -146,6 +146,7 @@ jobs:
     # TODO: create an sdist that can build without a custom environment
     needs: [build_wheels] 
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
     strategy:
       matrix:
         buildplat:


### PR DESCRIPTION
If we run test uploads on branches, we inherently will get clashes as pep440 versioning is linear by design.