### PR TITLE
Fix the support if "iolib" I/O pad.

### DIFF
--- a/cumulus/src/designflow/technos.py
+++ b/cumulus/src/designflow/technos.py
@@ -70,6 +70,8 @@ def setupCMOS ( checkToolkit=None ):
         af  = CRL.AllianceFramework.get()
         env = af.getEnvironment()
         env.setCLOCK( '^ck$|m_clock|^clk$' )
+        env.addSYSTEM_LIBRARY( library=(Where.checkToolkit / 'cells' / 'niolib').as_posix()
+                             , mode   =CRL.Environment.Append )
 
     Yosys.setLiberty( Where.cellsTop / 'sxlib' / 'sxlib.lib' )
     ShellEnv.RDS_TECHNO_NAME = (Where.allianceTop / 'etc' / 'cmos.rds').as_posix()

--- a/cumulus/src/plugins/core2chip/niolib.py
+++ b/cumulus/src/plugins/core2chip/niolib.py
@@ -20,9 +20,11 @@ Core2Chip configuration for the FlexLib I/O pad library ("niolib").
 
 import sys
 import re
+from   ...           import Cfg 
 from   ...Hurricane  import DbU, DataBase, UpdateSession, Breakpoint, \
                             Transformation , Instance , Net
-from   ...CRL        import Catalog, AllianceFramework
+from   ...CRL        import Catalog, AllianceFramework, CellGauge
+from   ...helpers    import overlay, l, u, n
 from   ...helpers.io import ErrorMessage, WarningMessage
 from   .core2chip    import CoreToChip as BaseCoreToChip, IoNet, IoPad
 
@@ -40,6 +42,17 @@ class CoreToChip ( BaseCoreToChip ):
         self.ioPadInfos   = [ BaseCoreToChip.IoPadInfo( IoPad.BIDIR, 'gpio', 'pad', ['i', 'o', 'oe'] )
                             ]
         self._getPadLib()
+        af = AllianceFramework.get()
+        cg = CellGauge.create( 'niolib'
+                             , 'METAL2'   # pin layer name.
+                             , l(   5.0)  # pitch.
+                             , l(1190.0)  # cell slice height.
+                             , l( 500.0)  # cell slice step.
+                             )
+        af.addCellGauge( cg )
+        self.conf.chipConf.ioPadGauge      = 'niolib'
+        self.conf.cfg.chip.padCoreSide     = 'North'
+        self.conf.cfg.chip.useAbstractPads = True
         return
 
     def _getPadLib ( self ):


### PR DESCRIPTION
In CoreToChip, the "iolib" I/O pad library an alternative to the "cmos" one. "cmos" uses the pxlib library while iolib uses a symbolic abstract version of the C4M (real) I/O pad.
  The initialization is a bit split as the "cmos" library are part of
Alliance, while "iolib" is in alliance-check-toolkit. So "iolib" is added at designflow.technos.setupCMOS().
  Setup additional configuration parameter directly in:
    core2chip.niolib.CoreToChip.__init__().