### PR TITLE
Fix wrong move up of non-preferred direction segments.

### DIFF
--- a/anabatic/src/GCell.cpp
+++ b/anabatic/src/GCell.cpp
@@ -1838,6 +1838,7 @@ namespace Anabatic {
     for ( ; (isegment != iend) ; isegment++ ) {
       unsigned int segmentDepth = Session::getRoutingGauge()->getLayerDepth((*isegment)->getLayer());
 
+      if ((*isegment)->isNonPref()) continue;
       if (segmentDepth < depth) continue;
       if (segmentDepth > depth) break;
 

--- a/katana/src/DataNegociate.cpp
+++ b/katana/src/DataNegociate.cpp
@@ -198,7 +198,9 @@ namespace Katana {
         _perpandicularFree.intersection( trackFree.inflate ( -sourceCap, -targetCap ) );
         cdebug_log(159,0) << "Source cap:"
                           << DbU::getValueString(perpandicular->getExtensionCap(Flags::Source)) << endl;
-      } else if (perpandicular->isFixedAxis() /*or _trackSegment->isDogleg()*/) {
+      } else if (       perpandicular->isFixedAxis()
+                and not perpandicular->isReduced()
+                /*or _trackSegment->isDogleg()*/) {
         RoutingPlane* plane = Session::getKatanaEngine()->getRoutingPlaneByLayer(perpandicular->getLayer());
         Track*        track = plane->getTrackByPosition( perpandicular->getAxis() );
         if (track and (perpandicular->getAxis() == track->getAxis())) {


### PR DESCRIPTION
We where moving up segments in non-preferred direction attached to terminals. As those where *fixed axis* we got M3 with fixed axis in conflict with normal vertical M3. This is unsolvable. Don't do it!

* Change: In GCell::stepNetDesaturate(), never move up a segment in non-preferred direction as they are usually attached to terminals, so they won't reduce the GCell density anyway.
* Change: In LayerAssign::RpsInRow::slacken(), do not slacken horizontals from M1 vertical terminals when they are tall enough. Arbitrarily choose above 6 H-tracks (should be made a configuration parameter).
* Change: In DataNegociate::update(), when processing perpandicular, we were taking into account "fixed axis" even when they were reduced (so not in tracks). Now do not.