### PR TITLE
Failures in PyPi uploads should fail workflows

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -193,7 +193,6 @@ jobs:
         with:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
-        continue-on-error: true
 
   upload_pypi:
     # TODO: create an sdist that can build without a custom environment
@@ -227,7 +226,6 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
-        continue-on-error: true
 
 #  build_sdist:
 #    name: Build sdist


### PR DESCRIPTION
For both test and production PyPi, if we try and do an upload and it fails, we should fail the GitHub upload workflow.

WARNING: This will fail when merged, as currently the uploads are failing due to version number clashes.