### PR TITLE
GDS: Actually skip discarded text

### DIFF
--- a/crlcore/src/ccore/gds/GdsParser.cpp
+++ b/crlcore/src/ccore/gds/GdsParser.cpp
@@ -1092,6 +1092,7 @@ namespace {
         cerr << Error( "GdsStream::readTextbody(): Discarted text is \"%s\"."
                      , _text.c_str()
                      ) << endl;
+        return _validSyntax;
       }
     }
     else {


### PR DESCRIPTION
I'm working on scoping out support for the GF180 foundry SRAM macros (and other SRAMs) in our flow, this was the first issue that I hit.

The GDS parser claims to be skipping text on unknown layers, but doesn't actually skip it, so crashes.