### PR TITLE
htree: Fix leaf contact selection

### DIFF
--- a/cumulus/src/plugins/block/htree.py
+++ b/cumulus/src/plugins/block/htree.py
@@ -271,7 +271,7 @@ class HTree ( object ):
 
         if qt.bl or qt.tl:
             trace( 550, '\tLeft branch\n' )
-            leafContact       = blContact if brContact else tlContact
+            leafContact       = blContact if blContact else tlContact
             leftSourceContact = gaugeConf.rpAccessByPlugName( qt.buffers[0]
                                                             , bufferConf.output
                                                             , ckNet


### PR DESCRIPTION
I hope I've understood the code correctly that this is a safe change. It fixes the case for me when the SRAM macro is placed at the bottom edge and obstructs the HTree there.