### PR TITLE
Never **ever** remove ${HOME}/.local again!

### DIFF
--- a/Makefile.LIP6
+++ b/Makefile.LIP6
@@ -113,7 +113,6 @@ clean_build: check_dir
 
 clean_pdm:
 	@echo "Removing all pip, pdm & venv installed files."
-	 rm -rf ${HOME}/.local
 	 rm -rf ${CORIOLIS_SRC}/.venv
 	 rm -f  ${CORIOLIS_SRC}/.pdm_python
 	 rm -rf ${CORIOLIS_SRC}/.pdm_plugins


### PR DESCRIPTION
In XDG compliant system, ~/.local/share contains software user's data. As I should have known.

Very *very* stupid mistake in ``Makefile.LIP6``. Took me more than on day to mostly undo the damage
on my system...