### PR TITLE
naming: Never remove underscores from original name

### DIFF
--- a/crlcore/src/ccore/toolbox/NamingScheme.cpp
+++ b/crlcore/src/ccore/toolbox/NamingScheme.cpp
@@ -99,7 +99,7 @@ namespace CRL {
       if (translated == '['  ) translated = leftPar;
       if (translated == ']'  ) translated = rightPar;
 
-      if (translated == '_') {
+      if (translated == '_' && refName[i] != '_') {
         if (vhdlName.empty()      ) continue;
         if (i == refName.size()-1) break;
         if (vhdlName.back() == '_') continue;


### PR DESCRIPTION
The rules to prevent duplicate or leading/trailing underscores make sense when other characters are being translated to underscores, but in my opinion make less sense when underscores are present in the original cell name.

For example, the gf180 cell `gf180mcu_fd_ip_sram__sram512x8m8wm1` would be renamed to `gf180mcu_fd_ip_sram_sram512x8m8wm1` by the code as-is, which would cause problems for GDS patching or timing analysis.

If you prefer a more conservative change that just preserves double (or more underscores) in names, I can also take that approach.