### PR TITLE
macro: Fix naming of wrapper

### DIFF
--- a/cumulus/src/plugins/macro/macro.py
+++ b/cumulus/src/plugins/macro/macro.py
@@ -128,7 +128,7 @@ class Macro ( object ):
         trace( 550, '+,', '\tMacro.__init__() {}\n'.format(macroCell) )
         af = AllianceFramework.get()
         self.cell = macroCell
-        self.wrapper = af.createCell(f"{self.cell.getName()}_wrapper_")
+        self.wrapper = af.createCell(f"{self.cell.getName()}_wrapper")
         inst = Instance.create(self.wrapper, f"inst", self.cell)
         inst.setTransformation( Transformation() )
         inst.setPlacementStatus( Instance.PlacementStatus.FIXED )


### PR DESCRIPTION
Following the discussion in #119 I learnt that trailing underscores are illegal in VHDL, so my previous wrapper code would have broken the VHDL export. This fixes it to be legal.