### PR TITLE
Fixes for AREF GDS parser

### DIFF
--- a/crlcore/src/ccore/gds/GdsParser.cpp
+++ b/crlcore/src/ccore/gds/GdsParser.cpp
@@ -1350,8 +1350,7 @@ namespace {
     string         masterName;
     uint16_t       columns = 0;
     uint16_t       rows    = 0;
-    DbU::Unit      dx      = 0;
-    DbU::Unit      dy      = 0;
+    Point          vx, vy;
     Point                       origin;
     Transformation::Orientation orient = Transformation::Orientation::ID;
 
@@ -1434,17 +1433,20 @@ namespace {
         else {
           cdebug_log(101,0) << "arrayOrigin: " << origin << endl;
         }
-        Transformation arrayTransf ( 0, 0, orient );
-        dx = arrayTransf.getX(coordinates[2] * _scale - origin.getX(),
-                              coordinates[3] * _scale - origin.getY()) / columns;
-        dy = arrayTransf.getY(coordinates[4] * _scale - origin.getX(),
-                              coordinates[5] * _scale - origin.getY()) / rows;
-        cdebug_log(101,0) << "dx=" << DbU::getValueString(dx) << endl;
-        cdebug_log(101,0) << "dy=" << DbU::getValueString(dy) << endl;
-        if (not dx and (columns > 1))
+        vx.setX((coordinates[2] * _scale - origin.getX()) / columns);
+        vx.setY((coordinates[3] * _scale - origin.getY()) / columns);
+        vy.setX((coordinates[4] * _scale - origin.getX()) / rows);
+        vy.setY((coordinates[5] * _scale - origin.getY()) / rows);
+        cdebug_log(101,0) << "vx=("
+                          << DbU::getValueString(vx.getX())
+                          << DbU::getValueString(vx.getY()) << ")" << endl;
+        cdebug_log(101,0) << "vy=("
+                          << DbU::getValueString(vy.getX())
+                          << DbU::getValueString(vy.getY()) << ")" << endl;
+        if (not vx.getX() and not vx.getY() and (columns > 1))
             cerr << Error( "GdsStream::readAref(): Null dx, but more than one column (%d)."
                         , columns ) << endl;
-        if (not dy and (rows > 1))
+        if (not vy.getX() and not vy.getY() and (rows > 1))
             cerr << Error( "GdsStream::readAref(): Null dy, but more than one row (%d)."
                         , rows ) << endl;
       }
@@ -1458,8 +1460,8 @@ namespace {
     if (_cell) {
       for ( uint32_t column=0 ; column < (uint32_t)columns ; ++column ) {
         for ( uint32_t row=0 ; row < (uint32_t)rows ; ++row ) {
-          DbU::Unit xpos = origin.getX() + column*dx;
-          DbU::Unit ypos = origin.getY() + row   *dy;
+          DbU::Unit xpos = origin.getX() + column*vx.getX() + row*vy.getX();
+          DbU::Unit ypos = origin.getY() + column*vx.getY() + row*vy.getY();
           Transformation itemTransf = Transformation( xpos, ypos, orient );
           
           cdebug_log(101,0) << "column=" << column

--- a/crlcore/src/ccore/gds/GdsParser.cpp
+++ b/crlcore/src/ccore/gds/GdsParser.cpp
@@ -1387,10 +1387,10 @@ namespace {
       if (_xReflection) {
         switch ( orient ) {
           case Transformation::Orientation::ID: orient = Transformation::Orientation::MY; break;
-          case Transformation::Orientation::R1: orient = Transformation::Orientation::YR; break;
+          case Transformation::Orientation::R1: orient = Transformation::Orientation::XR; break;
           case Transformation::Orientation::R2: orient = Transformation::Orientation::MX; break;
-          case Transformation::Orientation::R3: orient = Transformation::Orientation::XR; break;
-          default:
+          case Transformation::Orientation::R3: orient = Transformation::Orientation::YR; break;
+          default:  
             cerr << Warning( "GdsStream::readAref(): Unsupported MX+Orientation (%s) combination for AREF (Instance) of \"%s\""
                            , getString(orient).c_str(), masterName.c_str() ) << endl;
         }
@@ -1418,6 +1418,11 @@ namespace {
       if (_cell) {
         DbU::Unit       oneGrid = DbU::fromGrid( 1 );
         const vector<int32_t> coordinates = _record.getInt32s();
+        if (coordinates.size() != 6) {
+          _validSyntax = false;
+          cdebug_tabw(101,-1);
+          return _validSyntax;
+        }
         origin.setX(coordinates[0] * _scale);
         origin.setY(coordinates[1] * _scale);
         if ( (origin.getX() % oneGrid) or (origin.getY() % oneGrid) ) {
@@ -1430,12 +1435,10 @@ namespace {
           cdebug_log(101,0) << "arrayOrigin: " << origin << endl;
         }
         Transformation arrayTransf ( 0, 0, orient );
-        dx = arrayTransf.getX(
-                        Point(coordinates[2] * _scale - origin.getX(),
-                              coordinates[3] * _scale - origin.getY())) / columns;
-        dy = arrayTransf.getY(
-                        Point(coordinates[4] * _scale - origin.getX(),
-                              coordinates[5] * _scale - origin.getY())) / rows;
+        dx = arrayTransf.getX(coordinates[2] * _scale - origin.getX(),
+                              coordinates[3] * _scale - origin.getY()) / columns;
+        dy = arrayTransf.getY(coordinates[4] * _scale - origin.getX(),
+                              coordinates[5] * _scale - origin.getY()) / rows;
         cdebug_log(101,0) << "dx=" << DbU::getValueString(dx) << endl;
         cdebug_log(101,0) << "dy=" << DbU::getValueString(dy) << endl;
         if (not dx and (columns > 1))


### PR DESCRIPTION
Fixed: orientation in case of xReflect

Steps were wrong in case of 90 and 270 as angle rows become columns and columns become rows.
Fix: made steps as vectors, so horizontal step could be actually vertical and vice versa.