### PR TITLE
Fix macro pin non pref

### DIFF
--- a/cumulus/src/plugins/macro/macro.py
+++ b/cumulus/src/plugins/macro/macro.py
@@ -229,26 +229,6 @@ class Macro ( object ):
                                        , bb.getWidth()
                                        , bb.getYMin()
                                        , bb.getYMax() )
-        if self.cell.getName().lower().startswith('gf180mcu_fd_ip_sram_xxxx'):
-            print( '  o  Ad-hoc patch for "{}".'.format(self.cell.getName()) )
-            # Extend pins 2um downwards so that they don't conflict with power supply when we add the via
-            for net in self.wrapper.getNets():
-                if net.isSupply():
-                    continue
-                for component in net.getComponents():
-                    if not NetExternalComponents.isExternal(component):
-                        continue
-                    bb = component.getBoundingBox()
-                    if not ab.isConstrainedBy(bb) or ab.getYMin() != bb.getYMin() or component.getLayer() != gaugeMetal2.getLayer():
-                        continue
-                    NetExternalComponents.setInternal(component)
-                    extension = Vertical.create( net
-                                       , gaugeMetal2.getLayer()
-                                       , bb.getXCenter()
-                                       , bb.getWidth()
-                                       , u(-2)
-                                       , bb.getYMin())
-                    NetExternalComponents.setExternal(extension)
         if self.cell.getName().lower() in [ 'pll', 'gds_pll', 'cmpt_pll' ]:
             print( '  o  Ad-hoc patch for "{}".'.format(self.cell.getName()) )
         self.innerAb = ab


### PR DESCRIPTION
Extending toward the south the I/O pin in case of layer change was the right move, but it was done too early.

We later detect that an I/O pin is usable if it is *exactly* ending on the abutment box, and that was no longer true.

So we do it *after* I/O pin detection. By the way, we add a security so we use only *one* of the potential output pin.
