### PR TITLE
Added layer map manupulation functions to LefImport

### DIFF
--- a/crlcore/src/ccore/crlcore/LefImport.h
+++ b/crlcore/src/ccore/crlcore/LefImport.h
@@ -20,6 +20,7 @@
 #include <hurricane/DbU.h>
 namespace Hurricane {
   class Library;
+  class Layer;
 }
 
 
@@ -40,6 +41,9 @@ namespace CRL {
       static void                setMergeLibrary        ( Hurricane::Library* );
       static void                setGdsForeignDirectory ( std::string path );
       static void                setPinFilter           ( DbU::Unit xThreshold, DbU::Unit yThreshold, uint32_t flags );
+      static Hurricane::Layer*   getLayer               ( std::string name);
+      static void                addLayer               ( std::string name, Hurricane::Layer* layer );
+      static void                clearLayer             ( std::string name );
   };
 
 

--- a/crlcore/src/ccore/lefdef/LefImport.cpp
+++ b/crlcore/src/ccore/lefdef/LefImport.cpp
@@ -129,6 +129,7 @@ namespace {
       static       DbU::Unit          fromLefUnits             ( int );
       static       Layer*             getLayer                 ( string );
       static       void               addLayer                 ( string, Layer* );
+      static       void               clearLayer               ( string );
       static       void               reset                    ();
       static       Library*           parse                    ( string file );
                                       LefParser                ( string file, string libraryName );
@@ -305,7 +306,6 @@ namespace {
     return NULL;
   }
 
-
   void  LefParser::addLayer ( string layerName, Layer* layer )
   {
     if (getLayer(layerName)) {
@@ -316,6 +316,11 @@ namespace {
     _layerLut[ layerName ] = layer;
   }
 
+  void LefParser::clearLayer ( string layerName )
+  {
+    auto item = _layerLut.find( layerName );
+    if (item != _layerLut.end()) _layerLut.erase(item);
+  }
 
   bool  LefParser::isUnmatchedLayer ( string layerName )
   {
@@ -815,7 +820,7 @@ namespace {
   {
     LefParser* parser = (LefParser*)ud;
 
-  //cerr << "       @ _pinCbk: " << pin->name() << endl;
+    //cerr << "       @ _pinCbk: " << pin->name() << endl;
 
     bool  created = false;
     parser->earlyGetCell( created );
@@ -1384,5 +1389,26 @@ namespace CRL {
 #endif
   }
 
+  Layer* LefImport::getLayer ( string name )
+  {
+#if defined(HAVE_LEFDEF)
+    return LefParser::getLayer( name );
+#else
+    return 0;
+#endif
+  }
 
+  void  LefImport::addLayer ( string name, Layer* layer )
+  {
+#if defined(HAVE_LEFDEF)
+    LefParser::addLayer( name, layer );
+#endif
+  }
+
+  void  LefImport::clearLayer ( string name )
+  {
+#if defined(HAVE_LEFDEF)
+    LefParser::clearLayer( name );
+#endif
+  }
 }  // CRL namespace.

--- a/crlcore/src/pyCRL/PyLefImport.cpp
+++ b/crlcore/src/pyCRL/PyLefImport.cpp
@@ -16,6 +16,7 @@
 
 #include "crlcore/PyLefImport.h"
 #include "hurricane/isobar/PyLibrary.h"
+#include "hurricane/isobar/PyLayer.h"
 #include <string>
 #include <sstream>
 
@@ -33,6 +34,7 @@ namespace  CRL {
   using Hurricane::Error;
   using Hurricane::Warning;
   using Hurricane::Library;
+  using Hurricane::Layer;
   using Isobar::ProxyProperty;
   using Isobar::ProxyError;
   using Isobar::ConstructorError;
@@ -46,6 +48,9 @@ namespace  CRL {
   using Isobar::PyLibrary_Link;
   using Isobar::PyTypeLibrary;
   using Isobar::PyLibrary;
+  using Isobar::PyLayer_Link;
+  using Isobar::PyTypeLayer;
+  using Isobar::PyLayer;
 
 
 extern "C" {
@@ -143,6 +148,58 @@ extern "C" {
     Py_RETURN_NONE;
   }
 
+  static PyObject* PyLefImport_getLayer ( PyObject*, PyObject* args )
+  {
+    cdebug_log(30,0) << "PyLefImport_getLayer()" << endl;
+    Layer* layer = NULL;
+    HTRY
+      char* name = NULL;
+      if (PyArg_ParseTuple( args, "s:LefImport.getLayer", &name )) {
+        layer = LefImport::getLayer( name );
+      } else {
+        PyErr_SetString ( ConstructorError, "LefImport.getLayer(): Bad type or bad number of parameters." );
+        return NULL;
+      }
+    HCATCH
+    return (PyObject*)PyLayer_Link(layer);
+  }
+
+  static PyObject* PyLefImport_addLayer ( PyObject*, PyObject* args )
+  {
+    cdebug_log(30,0) << "PyLefImport_addLayer()" << endl;
+    HTRY
+      char* name = NULL;
+      PyObject* pyLayer = NULL;
+      if (PyArg_ParseTuple( args, "sO:LefImport.addLayer", &name, &pyLayer )) {
+        Layer* layer = PYLAYER_O(pyLayer);
+        if (layer == NULL) {
+          PyErr_SetString( ConstructorError
+                        , "PyLefImport.addLayer(): Second parameter is not of Layer type" );
+          return NULL;
+        }
+        LefImport::addLayer( name, layer );
+      } else {
+        PyErr_SetString ( ConstructorError, "LefImport.addLayer(): Bad type or bad number of parameters." );
+        return NULL;
+      }
+    HCATCH
+    Py_RETURN_NONE;
+  }
+
+  static PyObject* PyLefImport_clearLayer ( PyObject*, PyObject* args )
+  {
+    cdebug_log(30,0) << "PyLefImport_clearLayer()" << endl;
+    HTRY
+      char* name = NULL;
+      if (PyArg_ParseTuple( args, "s:LefImport.clearLayer", &name )) {
+        LefImport::clearLayer( name );
+      } else {
+        PyErr_SetString ( ConstructorError, "LefImport.clearLayer(): Bad type or bad number of parameters." );
+        return NULL;
+      }
+    HCATCH
+    Py_RETURN_NONE;
+  }
 
   // Standart Destroy (Attribute).
 
@@ -158,6 +215,12 @@ extern "C" {
                                 , "Set the directory where to find FOREIGN GDS files." }
     , { "setPinFilter"          , (PyCFunction)PyLefImport_setPinFilter          , METH_VARARGS|METH_STATIC
                                 , "Select the way Rectilinear pins are converted to one rectangle." }
+    , { "getLayer"              , (PyCFunction)PyLefImport_getLayer              , METH_VARARGS|METH_STATIC
+                                , "Get Layer from LefImport map." }
+    , { "addLayer"              , (PyCFunction)PyLefImport_addLayer              , METH_VARARGS|METH_STATIC
+                                , "Add Layer to LefImport map." }
+    , { "clearLayer"              , (PyCFunction)PyLefImport_clearLayer          , METH_VARARGS|METH_STATIC
+                                , "Remove Layer from LefImport map." }
   //, { "destroy"               , (PyCFunction)PyLefImport_destroy  , METH_VARARGS
   //                            , "Destroy the associated hurricane object. The python object remains." }
     , {NULL, NULL, 0, NULL}     /* sentinel */


### PR DESCRIPTION
Python functions added to LefImport:

addLayer - add LEF layer name mapped to existing layer

getLayer - get layer mapped by LEF layer name

clearLayer - remove LEF layer name mapping


With these functions it is possible to import LEF with it's layer names mapped to proper existing layers.