### PR TITLE
build: Fix missing parameter for add_project_argumetns in meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -28,7 +28,7 @@ add_project_arguments(
 )
 
 if get_option('check-database')
-  add_project_arguments('-DCHECK_DATABASE')
+  add_project_arguments('-DCHECK_DATABASE', language: ['c', 'cpp'])
 endif
 
 py = import('python').find_installation(pure:false)


### PR DESCRIPTION
`language` is a required parameter for `add_project_arguments`.