### PR TITLE
Fix the bad constraints restrictions in relaxOverConstraineds().

### DIFF
--- a/anabatic/src/AnabaticEngine.cpp
+++ b/anabatic/src/AnabaticEngine.cpp
@@ -1266,22 +1266,26 @@ namespace Anabatic {
              and north->canDrag()
              and (south->getNet() != north->getNet())
              and (south->getX  () == north->getX  ()) ) {
-            Interval constraints ( gcell->getYMin(), north->getCBYMin() /*- pitch3*/ );
-            AutoSegment* terminal = south->getSegment();
-            AutoContact* opposite = terminal->getOppositeAnchor( south );
+            if (south->getSegment()->isVertical()) {
+              Interval     constraints ( gcell->getYMin(), north->getCBYMin() /*- pitch3*/ );
+              AutoSegment* terminal    = south->getSegment();
+              AutoContact* opposite    = terminal->getOppositeAnchor( south );
 
-            for ( AutoSegment* segment : AutoSegments_OnContact(terminal,opposite->base()) ) {
-              segment->mergeUserConstraints( constraints );
-              constraineds.insert( segment );
+              for ( AutoSegment* segment : AutoSegments_OnContact(terminal,opposite->base()) ) {
+                segment->mergeUserConstraints( constraints );
+                constraineds.insert( segment );
+              }
             }
 
-            constraints = Interval( south->getCBYMax() /*+ pitch3*/, gcell->getYMax() );
-            terminal    = north->getSegment();
-            opposite    = terminal->getOppositeAnchor( north );
+            if (north->getSegment()->isVertical()) {
+              Interval     constraints = Interval( south->getCBYMax() /*+ pitch3*/, gcell->getYMax() );
+              AutoSegment* terminal    = north->getSegment();
+              AutoContact* opposite    = terminal->getOppositeAnchor( north );
 
-            for ( AutoSegment* segment : AutoSegments_OnContact(terminal,opposite->base()) ) {
-              segment->mergeUserConstraints( constraints );
-              constraineds.insert( segment );
+              for ( AutoSegment* segment : AutoSegments_OnContact(terminal,opposite->base()) ) {
+                segment->mergeUserConstraints( constraints );
+                constraineds.insert( segment );
+              }
             }
           }
         }


### PR DESCRIPTION
* Bug: In AnabaticEngine::relaxOverConstraineds(), when two terminals are vertically aligned, apply the constraints restrictions *only* if they are connected with V-NP + H topology, and not H-V. This was hapening for horizonal METAL1 terminals.