### PR TITLE
Liberty One line init + fixes

### DIFF
--- a/crlcore/src/liberty/ComplexValue.cpp
+++ b/crlcore/src/liberty/ComplexValue.cpp
@@ -17,7 +17,6 @@
 #include "crlcore/liberty/Value.h"
 #include "crlcore/liberty/ValueString.h"
 #include <string>
-#include <string_view>
 
 namespace Liberty {
 
@@ -27,13 +26,7 @@ namespace Liberty {
     clear();
   }
 
-  void ComplexValue::set(const std::string &value)
-  {
-    _values.push_back(new ValueString());
-    _values.back()->set(value);
-  }
-
-  void ComplexValue::set(const std::string_view &value)
+  void ComplexValue::set(std::string value)
   {
     _values.push_back(new ValueString());
     _values.back()->set(value);

--- a/crlcore/src/liberty/Group.cpp
+++ b/crlcore/src/liberty/Group.cpp
@@ -22,7 +22,6 @@
 #include <iostream>
 #include <regex>
 #include <string>
-#include <string_view>
 #include <vector>
 
 namespace Liberty {
@@ -60,7 +59,7 @@ namespace Liberty {
     _statements.push_back(statement);
   }
 
-  Group *Group::getGroup(const std::string &group_name) const
+  Group *Group::getGroup(std::string group_name) const
   {
     auto ret = std::find_if(_statements.begin(), _statements.end(), [&](Statement *item){
       if (not item->isGroup())
@@ -73,7 +72,7 @@ namespace Liberty {
     return (*ret)->getAsGroup();
   }
 
-  std::vector<Group *> Group::getGroups(const std::string &group_name_regex) const
+  std::vector<Group *> Group::getGroups(std::string group_name_regex) const
   {
     std::regex rgx(group_name_regex);
     std::vector<Group *> ret;
@@ -87,7 +86,7 @@ namespace Liberty {
     return ret;
   }
 
-  Attribute *Group::getAttribute(const std::string &attribute_name) const
+  Attribute *Group::getAttribute(std::string attribute_name) const
   {
     auto it = _attributes.find(attribute_name);
     if (it != _attributes.end()) {
@@ -101,11 +100,7 @@ namespace Liberty {
     return _library;
   }
 
-  void Group::setName(const std::string &name) {
-    _name = name;
-  }
-
-  void Group::setName(std::string_view &name) {
+  void Group::setName(std::string name) {
     _name = name;
   }
 

--- a/crlcore/src/liberty/Library.cpp
+++ b/crlcore/src/liberty/Library.cpp
@@ -30,10 +30,10 @@
 
 namespace Liberty {
 
-  Library::Library(const std::string &filepath):  SimpleGroup(nullptr)
-                                                , _path(filepath)
-                                                , _cells()
-                                                , _parsed(false)
+  Library::Library(std::string filepath):  SimpleGroup(nullptr)
+                                          , _path(filepath)
+                                          , _cells()
+                                          , _parsed(false)
   {}
 
   Library::~Library() {}
@@ -48,7 +48,7 @@ namespace Liberty {
     return _parsed;
   }
 
-  Group *Library::getCellGroup(const std::string &cell_name) const
+  Group *Library::getCellGroup(std::string cell_name) const
   {
     auto it = _cells.find(cell_name);
     if (it != _cells.end()) {
@@ -57,13 +57,13 @@ namespace Liberty {
     return nullptr;
   }
 
-  void Library::_include(const std::string &filename) {
+  void Library::_include(std::string filename) {
     std::cerr << "[CRITICAL WARNING] Trying to parse include directive for " << filename << " "
       << "but that feature is not yet available. "
       << "Parts of your library are probably not parsed and will be missing." << std::endl;
   }
 
-  void Library::addCellGroup(const std::string &cell_name, Group *group) {
+  void Library::addCellGroup(std::string cell_name, Group *group) {
     auto it = _cells.find(cell_name);
     if (it != _cells.end()) {
       if (it->second)

--- a/crlcore/src/liberty/Library.cpp
+++ b/crlcore/src/liberty/Library.cpp
@@ -33,13 +33,19 @@ namespace Liberty {
   Library::Library(const std::string &filepath):  SimpleGroup(nullptr)
                                                 , _path(filepath)
                                                 , _cells()
+                                                , _parsed(false)
   {}
 
   Library::~Library() {}
 
   bool Library::load() {
+    if (_parsed) {
+      std::cerr << "[INFO] " << _path << " was already loaded." << std::endl;
+      return _parsed;
+    }
     Parser parser(_path.string());
-    return parser.parse(this);
+    _parsed = parser.parse(this);
+    return _parsed;
   }
 
   Group *Library::getCellGroup(const std::string &cell_name) const

--- a/crlcore/src/liberty/Parser.cpp
+++ b/crlcore/src/liberty/Parser.cpp
@@ -30,7 +30,7 @@
 
 namespace Liberty {
 
-  Parser::Parser(const std::string &filepath): _tokenizer(filepath), _filepath(filepath) {}
+  Parser::Parser(std::string filepath): _tokenizer(filepath), _filepath(filepath) {}
 
   Parser::~Parser() {}
 
@@ -93,8 +93,8 @@ namespace Liberty {
             case QuotedExpression:
               to_add = new Attribute(current);
               value_str = new ValueString;
-              value_str->set(t.str);
-              to_add->setName(waiting.front().str);
+              value_str->set(std::string(t.str));
+              to_add->setName(std::string(waiting.front().str));
               waiting.pop();
               to_add->setValue(value_str);
               current->addStatement(to_add);
@@ -162,11 +162,11 @@ namespace Liberty {
                 if (waiting.size() != 3)
                   return _print_error(t);
                 define = new Define(current);
-                define->setAttributeName(waiting.front().str);
+                define->setAttributeName(std::string(waiting.front().str));
                 waiting.pop();
-                define->setGroupName(waiting.front().str);
+                define->setGroupName(std::string(waiting.front().str));
                 waiting.pop();
-                define->setAttributeType(waiting.front().str);
+                define->setAttributeType(std::string(waiting.front().str));
                 waiting.pop();
                 break;
               default:
@@ -188,25 +188,25 @@ namespace Liberty {
                     CurrentIsLibrary = false;
                   } else
                     sgroup = new SimpleGroup(current);
-                  sgroup->setName(waiting.front().str);
+                  sgroup->setName(std::string(waiting.front().str));
                   waiting.pop();
-                  sgroup->setGroupIdentifier(waiting.front().str);
+                  sgroup->setGroupIdentifier(std::string(waiting.front().str));
                   current->addStatement(sgroup);
                   current = sgroup;
                   waiting.pop();
                 } else if (waiting.size() > 2) {
                   ComplexGroup *cgroup = new ComplexGroup(current);
-                  cgroup->setName(waiting.front().str);
+                  cgroup->setName(std::string(waiting.front().str));
                   waiting.pop();
                   while (not waiting.empty()) {
-                    cgroup->addVariables(waiting.front().str);
+                    cgroup->addVariables(std::string(waiting.front().str));
                     waiting.pop();
                   }
                   current->addStatement(cgroup);
                   current = cgroup;
                 } else if (waiting.size() == 1) {
                   AnonymousGroup *agroup = new AnonymousGroup(current);
-                  agroup->setName(waiting.front().str);
+                  agroup->setName(std::string(waiting.front().str));
                   current->addStatement(agroup);
                   current = agroup;
                   waiting.pop();
@@ -219,10 +219,10 @@ namespace Liberty {
                 attribute = new Attribute(current);
                 complex_value = new ComplexValue;
                 attribute->setValue(complex_value);
-                attribute->setName(waiting.front().str);
+                attribute->setName(std::string(waiting.front().str));
                 waiting.pop();
                 while (not waiting.empty()) {
-                  complex_value->set(waiting.front().str);
+                  complex_value->set(std::string(waiting.front().str));
                   waiting.pop();
                 }
                 current->addStatement(attribute);

--- a/crlcore/src/liberty/SimpleGroup.cpp
+++ b/crlcore/src/liberty/SimpleGroup.cpp
@@ -17,7 +17,6 @@
 #include "crlcore/liberty/Library.h"
 #include "crlcore/liberty/SimpleGroup.h"
 #include <string>
-#include <string_view>
 
 namespace Liberty {
 
@@ -25,14 +24,7 @@ namespace Liberty {
 
   SimpleGroup::~SimpleGroup() {}
 
-  void SimpleGroup::setGroupIdentifier(const std::string &group_id)
-  {
-    _group_identifier = group_id;
-    if (getName() == "cell")
-      getLibrary()->addCellGroup(_group_identifier, this);
-  }
-
-  void SimpleGroup::setGroupIdentifier(const std::string_view &group_id)
+  void SimpleGroup::setGroupIdentifier(std::string group_id)
   {
     _group_identifier = group_id;
     if (getName() == "cell")

--- a/crlcore/src/liberty/crlcore/liberty/Attribute.h
+++ b/crlcore/src/liberty/crlcore/liberty/Attribute.h
@@ -16,7 +16,6 @@
 #pragma once
 #include "Statement.h"
 #include "Value.h"
-#include <string>
 
 namespace Liberty {
 

--- a/crlcore/src/liberty/crlcore/liberty/ComplexGroup.h
+++ b/crlcore/src/liberty/crlcore/liberty/ComplexGroup.h
@@ -16,7 +16,6 @@
 #pragma once
 #include "Group.h"
 #include <string>
-#include <string_view>
 #include <vector>
 
 namespace Liberty {
@@ -35,24 +34,18 @@ namespace Liberty {
       ComplexGroup(Group *parent);
       ~ComplexGroup();
 
-      inline        void                      addVariables(const std::string &variable)                     ;
-      inline        void                      addVariables(const std::string_view &variable)                ;
-      inline const  std::vector<std::string> &getVariables()                                  const         ;
-      inline        std::string               getGroupName()                                  const override;
+      inline        void                      addVariables(std::string variable)                ;
+      inline const  std::vector<std::string> &getVariables()                      const         ;
+      inline        std::string               getGroupName()                      const override;
 
 
     private:
       std::vector<std::string> _variables;
   };
 
-  inline void ComplexGroup::addVariables(const std::string &variable)
+  inline void ComplexGroup::addVariables(std::string variable)
   {
     _variables.push_back(variable);
-  }
-
-  inline void ComplexGroup::addVariables(const std::string_view &variable)
-  {
-    _variables.push_back(std::string(variable));
   }
 
   inline const std::vector<std::string> &ComplexGroup::getVariables() const

--- a/crlcore/src/liberty/crlcore/liberty/ComplexValue.h
+++ b/crlcore/src/liberty/crlcore/liberty/ComplexValue.h
@@ -33,10 +33,9 @@ namespace Liberty {
       ComplexValue();
       ~ComplexValue();
 
-      std::string getAsString ()                          const override;
-      void        set         (const std::string &value)        override;
-      void        set         (const std::string_view &value)           ;
-      void        clear       ()                                        ;
+      std::string getAsString ()                  const override;
+      void        set         (std::string value)       override;
+      void        clear       ()                                ;
     private:
       std::vector<ValueString*> _values;
   };

--- a/crlcore/src/liberty/crlcore/liberty/Define.h
+++ b/crlcore/src/liberty/crlcore/liberty/Define.h
@@ -15,6 +15,7 @@
 
 #pragma once
 #include "Statement.h"
+#include <string>
 
 namespace Liberty {
 
@@ -36,12 +37,9 @@ namespace Liberty {
       inline const  std::string  &getGroupName      () const         ;
       inline const  std::string  &getAttributeType  () const         ;
 
-      inline        void          setAttributeName  ( const std::string       &name       );
-      inline        void          setAttributeName  ( const std::string_view  &name       );
-      inline        void          setAttributeType  ( const std::string       &type       );
-      inline        void          setAttributeType  ( const std::string_view  &type       );
-      inline        void          setGroupName      ( const std::string       &group_name );
-      inline        void          setGroupName      ( const std::string_view  &group_name );
+      inline        void          setAttributeName  (std::string name      );
+      inline        void          setAttributeType  (std::string type      );
+      inline        void          setGroupName      (std::string group_name);
     private:
       std::string   _group_name     ;
       std::string   _attribute_type ; // should be specific type
@@ -53,11 +51,8 @@ namespace Liberty {
   inline const  std::string  &Define::getAttributeName()  const { return _name;           }
   inline const  std::string  &Define::getAttributeType()  const { return _attribute_type; }
 
-  inline  void  Define::setAttributeName(const std::string      &name       ) { _name           = name      ;}
-  inline  void  Define::setAttributeName(const std::string_view &name       ) { _name           = name      ;}
-  inline  void  Define::setAttributeType(const std::string      &type       ) { _attribute_type = type      ;}
-  inline  void  Define::setAttributeType(const std::string_view &type       ) { _attribute_type = type      ;}
-  inline  void  Define::setGroupName    (const std::string      &group_name ) { _group_name     = group_name;}
-  inline  void  Define::setGroupName    (const std::string_view &group_name ) { _group_name     = group_name;}
+  inline  void  Define::setAttributeName(std::string name       ) { _name           = name      ;}
+  inline  void  Define::setAttributeType(std::string type       ) { _attribute_type = type      ;}
+  inline  void  Define::setGroupName    (std::string group_name ) { _group_name     = group_name;}
 
 }

--- a/crlcore/src/liberty/crlcore/liberty/Group.h
+++ b/crlcore/src/liberty/crlcore/liberty/Group.h
@@ -18,7 +18,6 @@
 #include "Attribute.h"
 #include <map>
 #include <string>
-#include <string_view>
 #include <vector>
 
 namespace Liberty {
@@ -47,14 +46,13 @@ namespace Liberty {
               inline void         clear_statements()                                      ;
       virtual inline std::string  getGroupName    ()                      const        = 0;
 
-      void setName (const std::string      &name) override;
-      void setName (      std::string_view &name) override;
+      void setName (std::string name) override;
 
       inline const  std::vector<Statement*> &getStatements() const;
 
-      Group      *getGroup    ( const std::string &group_name     ) const;
-      std::vector<Group*> getGroups    ( const std::string &group_name_regex) const;
-      Attribute  *getAttribute( const std::string &attribute_name ) const;
+      Group              *getGroup    ( std::string group_name     ) const;
+      std::vector<Group*> getGroups   ( std::string group_name_regex)const;
+      Attribute          *getAttribute( std::string attribute_name ) const;
     protected:
       // group_name of group is in the parent class Statement.
       std::vector< Statement* >           _statements;

--- a/crlcore/src/liberty/crlcore/liberty/Library.h
+++ b/crlcore/src/liberty/crlcore/liberty/Library.h
@@ -29,18 +29,18 @@ namespace Liberty {
    * */
   class Library: public SimpleGroup {
     public:
-      Library (const std::string &filepath);
+      Library (std::string filepath);
       ~Library ();
 
-              Group      *getCellGroup(const std::string &cell_name               ) const ;
-              void        addCellGroup(const std::string &cell_name, Group *group )       ;
-              void        mapLibertyToDb (Hurricane::DataBase *db)                  const ;
-      inline  std::string getFilePath ()                                            const ;
+              Group      *getCellGroup  (std::string cell_name              ) const ;
+              void        addCellGroup  (std::string cell_name, Group *group)       ;
+              void        mapLibertyToDb(Hurricane::DataBase *db            ) const ;
+      inline  std::string getFilePath   ()                                    const ;
 
       bool load(); /// Process the actual loading of library.
 
     private:
-      void _include(const std::string &filename);
+      void _include(std::string filename);
     private:
       std::filesystem::path         _path   ;  /// Library search path (file directory for includes)
       std::map<std::string, Group*> _cells  ;  /// Contains cells (for search only)

--- a/crlcore/src/liberty/crlcore/liberty/Library.h
+++ b/crlcore/src/liberty/crlcore/liberty/Library.h
@@ -44,6 +44,7 @@ namespace Liberty {
     private:
       std::filesystem::path         _path   ;  /// Library search path (file directory for includes)
       std::map<std::string, Group*> _cells  ;  /// Contains cells (for search only)
+      bool                          _parsed ;  /// Wether liberty has already been successfully parsed
   };
 
   inline std::string Library::getFilePath() const

--- a/crlcore/src/liberty/crlcore/liberty/Parser.h
+++ b/crlcore/src/liberty/crlcore/liberty/Parser.h
@@ -25,7 +25,7 @@ namespace Liberty {
    * */
   class Parser {
     public:
-      Parser(const std::string &filepath);
+      Parser(std::string filepath);
       ~Parser();
 
       bool parse(Library *lib);

--- a/crlcore/src/liberty/crlcore/liberty/SimpleGroup.h
+++ b/crlcore/src/liberty/crlcore/liberty/SimpleGroup.h
@@ -16,7 +16,6 @@
 #pragma once
 #include "Group.h"
 #include <string>
-#include <string_view>
 
 namespace Liberty {
 
@@ -34,10 +33,9 @@ namespace Liberty {
       SimpleGroup(Group *parent);
       ~SimpleGroup();
 
-                    void          setGroupIdentifier(const std::string &group_id)                     ;
-                    void          setGroupIdentifier(const std::string_view &group_id)                ;
-      inline const  std::string  &getGroupIdentifier()                                  const         ;
-      inline        std::string   getGroupName()                                        const override;
+                    void          setGroupIdentifier(std::string group_id)                ;
+      inline const  std::string  &getGroupIdentifier()                      const         ;
+      inline        std::string   getGroupName      ()                      const override;
 
     private:
       std::string _group_identifier;

--- a/crlcore/src/liberty/crlcore/liberty/Statement.h
+++ b/crlcore/src/liberty/crlcore/liberty/Statement.h
@@ -41,8 +41,7 @@ namespace Liberty {
                       Attribute    *getAsAttribute()       ;
                       Define       *getAsDefine   ()       ;
 
-      inline virtual void setName(const std::string      &name);
-      inline virtual void setName(      std::string_view &name);
+      inline virtual void setName(std::string name);
 
     protected:
       Group      *_parent;
@@ -55,11 +54,8 @@ namespace Liberty {
   inline        bool          Statement::isAttribute  ()  const { return false;   }
   inline        bool          Statement::isDefine     ()  const { return false;   }
 
-  inline void Statement::setName( const std::string &name ) {
-    _name = name;
-  }
-
-  inline void Statement::setName( std::string_view &name ) {
+  inline void Statement::setName( std::string name )
+  {
     _name = name;
   }
 

--- a/crlcore/src/liberty/crlcore/liberty/Tokenizer.h
+++ b/crlcore/src/liberty/crlcore/liberty/Tokenizer.h
@@ -14,6 +14,7 @@
 // +-----------------------------------------------------------------+
 
 #pragma once
+#include <cstddef>
 #include <string>
 #include <string_view>
 #include "Reader.h"

--- a/crlcore/src/liberty/crlcore/liberty/Value.h
+++ b/crlcore/src/liberty/crlcore/liberty/Value.h
@@ -27,8 +27,8 @@ namespace Liberty {
       Value();
       virtual ~Value() = 0;
 
-      virtual std::string getAsString()                 const = 0;
-      virtual void        set(const std::string &value)       = 0;
+      virtual std::string getAsString()          const = 0;
+      virtual void        set(std::string value)       = 0;
     private:
   };
 

--- a/crlcore/src/liberty/crlcore/liberty/ValueString.h
+++ b/crlcore/src/liberty/crlcore/liberty/ValueString.h
@@ -16,7 +16,6 @@
 #pragma once
 #include "Value.h"
 #include <string>
-#include <string_view>
 
 namespace Liberty {
 
@@ -29,15 +28,13 @@ namespace Liberty {
       ValueString();
       ~ValueString();
 
-      inline  std::string getAsString ()                              const override;
-      inline  void        set         (const std::string &value)            override;
-      inline  void        set         (const std::string_view &value)               ;
+      inline  std::string getAsString ()                  const override;
+      inline  void        set         (std::string value)       override;
     private:
       std::string _value;
   };
 
-  inline  std::string ValueString::getAsString  ()                              const { return _value;  }
-  inline  void        ValueString::set          (const std::string &value)            { _value = value; }
-  inline  void        ValueString::set          (const std::string_view &value)       { _value = value; }
+  inline  std::string ValueString::getAsString()                  const { return _value;  }
+  inline  void        ValueString::set        (std::string value)       { _value = value; }
 
 }

--- a/cumulus/src/plugins/libertyParser.py
+++ b/cumulus/src/plugins/libertyParser.py
@@ -1,0 +1,29 @@
+# This file is part of the Coriolis Software.
+# Copyright (c) Sorbonne Université 2019-2023, All Rights Reserved
+#
+# +-----------------------------------------------------------------+
+# |                   C O R I O L I S                               |
+# |      C u m u l u s  -  P y t h o n   T o o l s                  |
+# |                                                                 |
+# |  Author      :                              Hippolyte MELICA    |
+# |  E-mail      :   hippolyte.melica@etu.sorbonne-universite.fr    |
+# | =============================================================== |
+# |  Python      :   "./plugins/liberty.py"                         |
+# +-----------------------------------------------------------------+
+
+import os
+
+def initLibertyLib(filepath:str) -> bool:
+    from coriolis import CRL
+    if not os.path.isfile(filepath):
+        print(f"[ERROR] {filepath} liberty file not found.")
+        return
+    print(f"[INFO] Liberty information will be parsed from {filepath}")
+    LibertyLib = CRL.LibertyLibrary(filepath=filepath)
+    if LibertyLib.load():
+        print("[INFO] Library file", filepath, "was successfully parsed.")
+    else:
+        print("[ERROR] parsing of ", filepath, " was not successful. CG will fail.")
+        return
+    LibertyLib.mapLibertyToDb() # at this point db owns LibertyLib
+    print("[INFO] Liberty informations were added to Hurricane database.")

--- a/cumulus/src/plugins/meson.build
+++ b/cumulus/src/plugins/meson.build
@@ -10,6 +10,7 @@ plugins = files([
   'aboutwindow.py',
   'checks.py',
   'conductor.py',
+  'libertyParser.py',
   'matrixplacer.py',
   'rsave.py',
   'rsaveall.py',


### PR DESCRIPTION
Some minor fixes to liberty, converting all `const std::string &` to `std::string`.

Adding one liner init for pdk. Usage :
```python
from coriolis.plugins import libertyParser
libertyParser.initLibertyLib("/path/to/liberty_file.lib")
```

This is needed for lip6/coriolis-pdk-gf180mcu#1 to be merged (only to use pdk with `enableLiberty=True`, pdk ***will not*** break without this).