### PR TITLE
Fix compilation with newer versions of libboost

### DIFF
--- a/crlcore/src/liberty/Group.cpp
+++ b/crlcore/src/liberty/Group.cpp
@@ -18,7 +18,6 @@
 #include "crlcore/liberty/Library.h"
 #include "crlcore/liberty/Statement.h"
 #include <algorithm>
-#include <boost/process/group.hpp>
 #include <iostream>
 #include <regex>
 #include <string>


### PR DESCRIPTION
Removing unused header