### PR TITLE
Ajout de calcul de l'ODC

### DIFF
--- a/cumulus/meson.build
+++ b/cumulus/meson.build
@@ -13,9 +13,6 @@ py.install_sources(chip, subdir: 'coriolis/plugins/chip')
 py.install_sources(core2chip, subdir: 'coriolis/plugins/core2chip')
 py.install_sources(harness, subdir: 'coriolis/plugins/harness')
 py.install_sources(macro, subdir: 'coriolis/plugins/macro')
+py.install_sources(odc, subdir: 'coriolis/plugins/odc')
 py.install_sources(sram, subdir: 'coriolis/plugins/sram')
 py.install_sources(tools, subdir: 'coriolis/tools')
-
-
-
-

--- a/cumulus/src/plugins/meson.build
+++ b/cumulus/src/plugins/meson.build
@@ -4,6 +4,7 @@ subdir('core2chip')
 subdir('harness')
 subdir('macro')
 subdir('sram')
+subdir('odc')
 
 plugins = files([
   '__init__.py',

--- a/cumulus/src/plugins/odc/CellODC.py
+++ b/cumulus/src/plugins/odc/CellODC.py
@@ -1,0 +1,146 @@
+# This file is part of the Coriolis Software.
+# Copyright (c) Sorbonne Université 2019-2023, All Rights Reserved
+#
+# +-----------------------------------------------------------------+
+# |                   C O R I O L I S                               |
+# |      C u m u l u s  -  P y t h o n   T o o l s                  |
+# |                                                                 |
+# |  Author      :                              Hippolyte MELICA    |
+# |  E-mail      :   hippolyte.melica@etu.sorbonne-universite.fr    |
+# | =============================================================== |
+# |  Python      :   "./plugins/odc/CellODC.py"                     |
+# +-----------------------------------------------------------------+
+
+import re
+
+from coriolis.CRL import getLibertyGroupFromCell
+from coriolis.Hurricane import Cell
+from sympy import Not, S, Xor, simplify, simplify_logic, symbols
+from sympy.parsing.sympy_parser import implicit_multiplication_application, parse_expr, standard_transformations
+
+
+def lib_expr_parsing(expression: str, pins: dict[str, S]):
+    clean_expr = expression.replace('!', '~')
+    clean_expr = clean_expr.replace('"', '')
+    transformations = standard_transformations + (implicit_multiplication_application,)
+    parsed_func = parse_expr(clean_expr, transformations=transformations, local_dict=pins)
+    return simplify(parsed_func)
+
+
+class CellODC:
+
+    def __init__(self, cell: Cell):
+        try:
+            master_cell = cell.getMasterCell()
+        except AttributeError:
+            master_cell = cell
+        self._master_cell: str = master_cell.getName()
+        self._pins_direction: dict[str, str] = {}  # dict of output pins, containing dict of input pins.
+        self._is_ff: bool = False
+        self._is_steering: bool = False
+        self._observability: dict[str, dict[str]] = {} # [output_pin, [input_pin, odc_func]]
+        pins_functions = {}
+
+        grp = getLibertyGroupFromCell(master_cell)
+        if grp is None:
+            print(f"[WARNING] No library information attached to {self._master_cell}")
+            return
+
+        # adding pins to list
+        pins = grp.getGroups("pin.*")
+        for pin in pins:
+            pin_name = re.search(r"\((.*)\)", pin.getGroupName()).group(1)
+            pin_direction = pin.getAttribute("direction").getValue()
+            self._pins_direction[pin_name] = pin_direction
+        local_dict = {pin_name: symbols(pin_name) for pin_name in self._pins_direction.keys()}
+
+        for pin in pins:
+            pin_name = re.search(r"\((.*)\)", pin.getGroupName()).group(1)
+            pin_direction = self._pins_direction[pin_name]
+            if pin_direction == "output":
+                function = pin.getAttribute("function")
+                if function is None:
+                    continue # no function for output in case of ff
+                function = function.getValue()
+                expr = lib_expr_parsing(function, local_dict)
+                func_symbols = expr.free_symbols
+                # checking wether function is three state
+                three_state = pin.getAttribute("three_state")
+                if three_state is not None:
+                    self._is_steering = True
+                    expr = Not(lib_expr_parsing(three_state.getValue().replace('"', ''), local_dict))
+                    self._observability[pin_name] = {
+                        p: expr for p in set([str(s) for s in func_symbols])
+                    }
+                else:
+                    self._observability[pin_name] = {
+                        p: S.true for p in set([str(s) for s in func_symbols])
+                    }
+                pins_functions[pin_name] = expr
+
+        # checking wether cell is a flip flop
+        ff_grp = grp.getGroups("ff\\(.*")
+        if len(ff_grp) >= 1:  # Attention, peut être ff et steering à la fois !!!! (reset...)
+            ff_grp = ff_grp[0]
+            # cell is ff
+            self._is_ff = True
+            # extracting outputs
+            match = re.search(r"\((\w*),?(\w*).*\)", ff_grp.getGroupName())
+            out = None
+            inv_out = None
+            if match:
+                out, inv_out = match.groups()
+            else:
+                print("[ERROR] flip-flop groups is not correctly formatted.")
+                raise SyntaxError
+            # will only traver through inputs used in next_state parameter
+            expr = lib_expr_parsing(ff_grp.getAttribute("next_state").getValue(), local_dict)
+            ff_symbols = expr.free_symbols
+            for output in [p_n for p_n, p_d in self._pins_direction.items() if p_d == "output"]:
+                self._observability[output] = {pin: S.true for pin in set([str(s) for s in ff_symbols])}
+            return
+
+        # if not already steering, we need to check derivative of outputs relatives to each input.
+        if not self._is_steering:
+            pin_not_steering = [] # we got to list all pins not steering to find the one that steers
+            input_pins = [pin for pin, direction in self._pins_direction.items() if direction == "input"]
+            for output_name, func in pins_functions.items():
+                for pin in input_pins:
+                    symbol = symbols(pin)
+                    f0 = func.subs(symbol, False)
+                    f1 = func.subs(symbol, True)
+                    derivative = simplify_logic(Xor(f0, f1))
+                    if derivative == S.true or derivative == S.false:
+                        return # TODO: is is really return and not continue ?
+                    symbols_of_derivative = derivative.free_symbols
+                    for p in input_pins:
+                        if p not in [str(s).replace("~", "") for s in symbols_of_derivative] + [pin]:
+                            pin_not_steering.append(pin)
+                            self._observability[output_name][pin] = derivative
+            if len(pin_not_steering) > 0:
+                for p in [str(s) for s in input_pins]:
+                    if p not in pin_not_steering:
+                        self._is_steering = True
+                        for output in self._observability.keys():
+                            self._observability[output].pop(p)
+
+    @property
+    def isFlipflop(self):
+        return self._is_ff
+
+    @property
+    def isSteering(self):
+        return self._is_steering
+
+    def print(self):
+        print(f"# {self._master_cell}")
+        print("# pins")
+        for pin, direction in self._pins_direction.items():
+            print(f"#   {pin}:{direction}")
+        print(f"# is FF        : {self._is_ff}")
+        print(f"# is isSteering: {self._is_steering}")
+        print("# functions")
+        for opin, inputs in self._observability.items():
+            print(f"#   {opin}:")
+            for ipin, func in inputs.items():
+                print(f"#     {ipin}: {func}")

--- a/cumulus/src/plugins/odc/CellODC.py
+++ b/cumulus/src/plugins/odc/CellODC.py
@@ -15,7 +15,7 @@ import re
 
 from coriolis.CRL import getLibertyGroupFromCell
 from coriolis.Hurricane import Cell
-from sympy import Not, S, Xor, simplify, simplify_logic, symbols
+from sympy import Not, S, Xor, simplify_logic, symbols
 from sympy.parsing.sympy_parser import implicit_multiplication_application, parse_expr, standard_transformations
 
 
@@ -24,7 +24,7 @@ def lib_expr_parsing(expression: str, pins: dict[str, S]):
     clean_expr = clean_expr.replace('"', '')
     transformations = standard_transformations + (implicit_multiplication_application,)
     parsed_func = parse_expr(clean_expr, transformations=transformations, local_dict=pins)
-    return simplify(parsed_func)
+    return simplify_logic(parsed_func)
 
 
 class CellODC:
@@ -71,6 +71,10 @@ class CellODC:
                     expr = Not(lib_expr_parsing(three_state.getValue().replace('"', ''), local_dict))
                     self._observability[pin_name] = {
                         p: expr for p in set([str(s) for s in func_symbols])
+                    }
+                    expr_symbols = expr.free_symbols
+                    self._observability[pin_name] |= {
+                        p: S.true for p in set([str(s) for s in expr_symbols])
                     }
                 else:
                     self._observability[pin_name] = {
@@ -122,7 +126,7 @@ class CellODC:
                     if p not in pin_not_steering:
                         self._is_steering = True
                         for output in self._observability.keys():
-                            self._observability[output].pop(p)
+                            self._observability[output][p] = S.true # non steering pins have observability
 
     @property
     def isFlipflop(self):

--- a/cumulus/src/plugins/odc/CellODC.py
+++ b/cumulus/src/plugins/odc/CellODC.py
@@ -35,7 +35,7 @@ class CellODC:
         except AttributeError:
             master_cell = cell
         self._master_cell: str = master_cell.getName()
-        self._pins_direction: dict[str, str] = {}  # dict of output pins, containing dict of input pins.
+        self._pins_direction: dict[str, str] = {}
         self._is_ff: bool = False
         self._is_steering: bool = False
         self._observability: dict[str, dict[str]] = {} # [output_pin, [input_pin, odc_func]]
@@ -115,7 +115,7 @@ class CellODC:
                     f1 = func.subs(symbol, True)
                     derivative = simplify_logic(Xor(f0, f1))
                     if derivative == S.true or derivative == S.false:
-                        return # TODO: is is really return and not continue ?
+                        break
                     symbols_of_derivative = derivative.free_symbols
                     for p in input_pins:
                         if p not in [str(s).replace("~", "") for s in symbols_of_derivative] + [pin]:

--- a/cumulus/src/plugins/odc/CellODCCache.py
+++ b/cumulus/src/plugins/odc/CellODCCache.py
@@ -1,0 +1,36 @@
+# This file is part of the Coriolis Software.
+# Copyright (c) Sorbonne Université 2019-2023, All Rights Reserved
+#
+# +-----------------------------------------------------------------+
+# |                   C O R I O L I S                               |
+# |      C u m u l u s  -  P y t h o n   T o o l s                  |
+# |                                                                 |
+# |  Author      :                              Hippolyte MELICA    |
+# |  E-mail      :   hippolyte.melica@etu.sorbonne-universite.fr    |
+# | =============================================================== |
+# |  Python      :   "./plugins/odc/CellODCCache.py"                |
+# +-----------------------------------------------------------------+
+
+from coriolis.Hurricane import Cell, Instance
+
+from .CellODC import CellODC
+
+
+class CellODCCache:
+    def __init__(self):
+        self._cell_cache: dict[str, CellODC] = {}
+
+    def __getitem__(self, key):
+        if type(key) is str:
+            return self._cell_cache[key]
+        elif type(key) is not Cell and type(key) is not Instance:
+            raise TypeError
+        try:
+            try:
+                master_cell = key.getMasterCell()
+            except AttributeError:
+                master_cell = key
+            return self._cell_cache[master_cell.getName()]
+        except KeyError:
+            self._cell_cache[master_cell.getName()] = CellODC(master_cell)
+            return self._cell_cache[master_cell.getName()]

--- a/cumulus/src/plugins/odc/FFDatabase.py
+++ b/cumulus/src/plugins/odc/FFDatabase.py
@@ -1,0 +1,74 @@
+# This file is part of the Coriolis Software.
+# Copyright (c) Sorbonne Université 2019-2023, All Rights Reserved
+#
+# +-----------------------------------------------------------------+
+# |                   C O R I O L I S                               |
+# |      C u m u l u s  -  P y t h o n   T o o l s                  |
+# |                                                                 |
+# |  Author      :                              Hippolyte MELICA    |
+# |  E-mail      :   hippolyte.melica@etu.sorbonne-universite.fr    |
+# | =============================================================== |
+# |  Python      :   "./plugins/odc/FFDatabase.py"                  |
+# +-----------------------------------------------------------------+
+
+from coriolis.Hurricane import Cell
+from sympy import Or, S, simplify_logic
+
+from .CellODC import CellODC
+
+
+class FFEntry:
+    def __init__(self):
+        self.function: S = S.true
+        self.name: str = ""
+
+    def __str__(self):
+        return f"{self.name}: {self.function}"
+
+    def simplify(self):
+        self.function = simplify_logic(self.function)
+
+
+class FFDatabase:
+    def __init__(self):
+        self._ff: dict[str, FFEntry] = {}
+        self._ffs: set[str] = set()
+        self._len = 0
+        self.edits = 0
+
+    def __contains__(self, cell):
+        if type(cell) is Cell:
+            return cell.getName() in self._ff
+        return cell in self._ff
+
+    def __getitem__(self, key):
+        return self._ff[key]
+
+    def addNewFF(self, ff: Cell, ff_info: CellODC, function):
+        if ff.getName() in self._ffs:
+            old_entry = self._ff[ff.getName()]
+            self._ff[ff.getName()].function = simplify_logic(Or(function, old_entry.function))
+            self.edits += 1
+            return True  # return true if walker should stop
+        else:
+            self._ffs.add(ff.getName())
+            entry = FFEntry()
+            entry.function = function
+            entry.name = ff.getName()
+            self._ff[ff.getName()] = entry
+        return False
+
+    def items(self):
+        return self._ff.items()
+
+    def __len__(self):
+        return len(self._ff)
+
+    def processFuncs(self):
+        print("Simplifying ODC functions (simplification forced, could take some time...)")
+        for nb, value in enumerate(self._ff.values()):
+            print(f"{nb}/{len(self._ff)} ({nb * 100 / len(self._ff):.2f}%)")
+            value.simplify()
+            print("\033[F\033[K", end="")
+        print("\033[F\033[K", end="")
+        print("Simplification done.")

--- a/cumulus/src/plugins/odc/FFDatabase.py
+++ b/cumulus/src/plugins/odc/FFDatabase.py
@@ -34,7 +34,6 @@ class FFDatabase:
         self._ff: dict[str, FFEntry] = {}
         self._ffs: set[str] = set()
         self._len = 0
-        self.edits = 0
 
     def __contains__(self, cell):
         if type(cell) is Cell:
@@ -47,8 +46,10 @@ class FFDatabase:
     def addNewFF(self, ff: Cell, ff_info: CellODC, function):
         if ff.getName() in self._ffs:
             old_entry = self._ff[ff.getName()]
-            self._ff[ff.getName()].function = simplify_logic(Or(function, old_entry.function))
-            self.edits += 1
+            if old_entry.function == S.true or function == S.true:
+                old_entry.function = S.true
+                return True
+            old_entry.function = simplify_logic(Or(function, old_entry.function))
             return True  # return true if walker should stop
         else:
             self._ffs.add(ff.getName())

--- a/cumulus/src/plugins/odc/FFDatabase.py
+++ b/cumulus/src/plugins/odc/FFDatabase.py
@@ -18,38 +18,44 @@ from .CellODC import CellODC
 
 
 def optimize_FFEntry(entry):
-    all = []
+    working = []
+    already_opti = []
     while len(entry.functions):
         func = entry.functions.pop(0)
         entry.no_opti = Or(entry.no_opti, func)
         atoms = func.atoms() - {f.args[0] for f in func.atoms(Not)}
         atoms |= func.atoms(Not)
-        all.append([atoms, func])
-    entry.functions = sorted(all, key=lambda x: len(x[0]))
-    all.clear()
-    while len(entry.functions) > 0:
-        atoms, func = entry.functions.pop(0)
+        working.append([atoms, func])
+    working = sorted(working, key=lambda x: len(x[0]))
+    while len(working) > 0:
+        atoms, func = working.pop(0)
         done = False
-        for i in range(len(entry.functions)):
-            if atoms.issubset(entry.functions[i][0]):
-                entry.functions[i][1] = simplify_logic(Or(func, entry.functions[i][1]), force=True)
-                entry.functions[i][0] = entry.functions[i][1].atoms() - {
-                    f.args[0] for f in entry.functions[i][1].atoms(Not)
+        for i in range(len(working)):
+            if atoms.issubset(working[i][0]):
+                working[i][1] = simplify_logic(Or(func, working[i][1]), force=True)
+                working[i][0] = working[i][1].atoms() - {
+                    f.args[0] for f in working[i][1].atoms(Not)
                 }
-                entry.functions[i][0] |= entry.functions[i][1].atoms(Not)
+                working[i][0] |= working[i][1].atoms(Not)
                 done = True
                 break
         if not done:
-            all.append([atoms, func])
+            already_opti.append([atoms, func])
         else:
-            entry.functions += all
-            all.clear()
-            entry.functions = sorted(entry.functions, key=lambda x: len(x[0]))
-    entry.functions.clear()
-    while len(all) > 1:
-        _, func = all.pop(0)
-        all[0][1] = simplify_logic(Or(func, all[0][1]))
-    entry.function = all[0][1]
+            working += already_opti
+            already_opti.clear()
+            working = sorted(working, key=lambda x: len(x[0]))
+    working.clear()
+    while len(already_opti) > 1:
+        _, func = already_opti.pop(0)
+        already_opti[0][1] = simplify_logic(Or(func, already_opti[0][1]))
+    if len(already_opti) == 0:
+        print("\033[F\033[K", end="")
+        print(f"[ERROR] Simplifying function for {entry.name}, default to True.")
+        print("")
+        entry.function = S.true
+        return
+    entry.function = already_opti[0][1]
 
 
 class FFEntry:
@@ -93,6 +99,7 @@ class FFDatabase:
             self._ffs.add(ff.getName())
             entry = FFEntry()
             entry.function = function
+            entry.functions.append(function)
             entry.name = ff.getName()
             self._ff[ff.getName()] = entry
         return False

--- a/cumulus/src/plugins/odc/FFDatabase.py
+++ b/cumulus/src/plugins/odc/FFDatabase.py
@@ -12,14 +12,52 @@
 # +-----------------------------------------------------------------+
 
 from coriolis.Hurricane import Cell
-from sympy import Or, S, simplify_logic
+from sympy import Not, Or, S, simplify_logic
 
 from .CellODC import CellODC
 
 
+def optimize_FFEntry(entry):
+    all = []
+    while len(entry.functions):
+        func = entry.functions.pop(0)
+        entry.no_opti = Or(entry.no_opti, func)
+        atoms = func.atoms() - {f.args[0] for f in func.atoms(Not)}
+        atoms |= func.atoms(Not)
+        all.append([atoms, func])
+    entry.functions = sorted(all, key=lambda x: len(x[0]))
+    all.clear()
+    while len(entry.functions) > 0:
+        atoms, func = entry.functions.pop(0)
+        done = False
+        for i in range(len(entry.functions)):
+            if atoms.issubset(entry.functions[i][0]):
+                entry.functions[i][1] = simplify_logic(Or(func, entry.functions[i][1]), force=True)
+                entry.functions[i][0] = entry.functions[i][1].atoms() - {
+                    f.args[0] for f in entry.functions[i][1].atoms(Not)
+                }
+                entry.functions[i][0] |= entry.functions[i][1].atoms(Not)
+                done = True
+                break
+        if not done:
+            all.append([atoms, func])
+        else:
+            entry.functions += all
+            all.clear()
+            entry.functions = sorted(entry.functions, key=lambda x: len(x[0]))
+    entry.functions.clear()
+    while len(all) > 1:
+        _, func = all.pop(0)
+        all[0][1] = simplify_logic(Or(func, all[0][1]))
+    entry.function = all[0][1]
+
+
 class FFEntry:
     def __init__(self):
-        self.function: S = S.true
+        self.function: S = S.false
+        self.no_opti: S = S.false
+        self.functions = list()
+        self.is_true = False
         self.name: str = ""
 
     def __str__(self):
@@ -32,6 +70,8 @@ class FFDatabase:
         self._ffs: set[str] = set()
         self._len = 0
         self.nets_true = set()
+        self.opti = 0
+        self.variables_removed = 0
 
     def __contains__(self, cell):
         if type(cell) is Cell:
@@ -47,7 +87,7 @@ class FFDatabase:
             if old_entry.function == S.true or function == S.true:
                 old_entry.function = S.true
                 return True
-            old_entry.function = simplify_logic(Or(function, old_entry.function))
+            old_entry.functions.append(function)
             return True  # return true if walker should stop
         else:
             self._ffs.add(ff.getName())
@@ -66,11 +106,16 @@ class FFDatabase:
     def __len__(self):
         return len(self._ff)
 
-    def processFuncs(self):
-        print("Simplifying ODC functions (simplification forced, could take some time...)")
-        for nb, value in enumerate(self._ff.values()):
-            print(f"{nb}/{len(self._ff)} ({nb * 100 / len(self._ff):.2f}%)")
-            value.simplify()
+    def compute_functions(self):
+        for i, entry in enumerate(self._ff.values()):
+            print(f"{i}/{len(self._ff)} ({i*100/len(self._ff):.2f}%), {self.opti} optimizations found")
+            if entry.function == S.true:
+                entry.functions.clear()
+                entry.no_opti = S.true
+                print("\033[F\033[K", end="")
+                continue
+            optimize_FFEntry(entry)
+            if entry.function != entry.no_opti:
+                self.opti += 1
+                self.variables_removed += len(entry.no_opti.atoms()) - len(entry.function.atoms())
             print("\033[F\033[K", end="")
-        print("\033[F\033[K", end="")
-        print("Simplification done.")

--- a/cumulus/src/plugins/odc/FFDatabase.py
+++ b/cumulus/src/plugins/odc/FFDatabase.py
@@ -25,15 +25,13 @@ class FFEntry:
     def __str__(self):
         return f"{self.name}: {self.function}"
 
-    def simplify(self):
-        self.function = simplify_logic(self.function)
-
 
 class FFDatabase:
     def __init__(self):
         self._ff: dict[str, FFEntry] = {}
         self._ffs: set[str] = set()
         self._len = 0
+        self.nets_true = set()
 
     def __contains__(self, cell):
         if type(cell) is Cell:
@@ -61,6 +59,9 @@ class FFDatabase:
 
     def items(self):
         return self._ff.items()
+
+    def values(self):
+        return self._ff.values()
 
     def __len__(self):
         return len(self._ff)

--- a/cumulus/src/plugins/odc/FFDatabase.py
+++ b/cumulus/src/plugins/odc/FFDatabase.py
@@ -11,6 +11,8 @@
 # |  Python      :   "./plugins/odc/FFDatabase.py"                  |
 # +-----------------------------------------------------------------+
 
+from queue import Queue
+
 from coriolis.Hurricane import Cell
 from sympy import Not, Or, S, simplify_logic
 
@@ -71,13 +73,15 @@ class FFEntry:
 
 
 class FFDatabase:
-    def __init__(self):
+    def __init__(self, enable_estimate=False):
         self._ff: dict[str, FFEntry] = {}
         self._ffs: set[str] = set()
         self._len = 0
         self.nets_true = set()
         self.opti = 0
         self.variables_removed = 0
+        self.enable_estimate = enable_estimate
+        self.path_ff: dict[int, set[str]] = {}
 
     def __contains__(self, cell):
         if type(cell) is Cell:
@@ -87,8 +91,10 @@ class FFDatabase:
     def __getitem__(self, key):
         return self._ff[key]
 
-    def addNewFF(self, ff: Cell, ff_info: CellODC, function):
+    def addNewFF(self, ff: Cell, ff_info: CellODC, function, path):
         if ff.getName() in self._ffs:
+            if self.enable_estimate:
+                self.path_ff[ff.getName()].update(path)
             old_entry = self._ff[ff.getName()]
             if old_entry.function == S.true or function == S.true:
                 old_entry.function = S.true
@@ -102,6 +108,8 @@ class FFDatabase:
             entry.functions.append(function)
             entry.name = ff.getName()
             self._ff[ff.getName()] = entry
+            if self.enable_estimate:
+                self.path_ff[ff.getName()] = set(path)
         return False
 
     def items(self):
@@ -126,3 +134,15 @@ class FFDatabase:
                 self.opti += 1
                 self.variables_removed += len(entry.no_opti.atoms()) - len(entry.function.atoms())
             print("\033[F\033[K", end="")
+
+    def compute_estimate(self):
+        results = {}
+        for ff, cells in self.path_ff.items():
+            affected = 1 if self._ff[ff].function != S.true else 0
+            for cell in cells:
+                try:
+                    results[cell].append(affected)
+                except KeyError:
+                    results[cell] = [affected]
+        calc_results = [sum(i)/len(i) for i in results.values()]
+        return sum(calc_results)/len(calc_results)

--- a/cumulus/src/plugins/odc/ODCWalker.py
+++ b/cumulus/src/plugins/odc/ODCWalker.py
@@ -40,6 +40,7 @@ def replaceSymbols(expr, correspondance):
 class ODCWalker:
     walker_number: int = 0
     iter_count = 0
+    iter_rep = []
 
     def __init__(
         self,
@@ -95,8 +96,6 @@ class ODCWalker:
             master_net = plug.getMasterNet()
             if master_net.getDirection() != Net.Direction.OUT:
                 continue
-            if plug is None:  # end of path, no instance means external net
-                continue
             if first_plug:
                 self._plug = plug
                 first_plug = False
@@ -115,7 +114,7 @@ class ODCWalker:
             if master_net.getDirection() != Net.Direction.IN or master_net.isSupply() or master_net.isClock():
                 continue
             if master_net.getName() not in odc_info._observability[master_output.getName()]:  # if pin is not observable
-                continue  # steering pins are not observable
+                continue
             if first:
                 if odc_info.isSteering:
                     ext_expr = replaceSymbols(
@@ -136,12 +135,14 @@ class ODCWalker:
             self._function = new_function
 
     def run(self):
+        iter = 0
         while self._plug is not None or self._net is not None:
+            iter += 1
             ODCWalker.iter_count += 1
             if not self._from_plug:
                 self.iterate_over_net()
                 if self._plug is None:  # no plugs were found
-                    return
+                    break
             else:
                 self._from_plug = False
             # All plugs explored
@@ -154,8 +155,11 @@ class ODCWalker:
             if odc_info.isFlipflop:
                 stop_there = self._results.addNewFF(instance, odc_info, self._function)
                 if stop_there:
-                    return  # A younger mike did already leave from there
+                    break  # A younger mike did already leave from there
                 self._function = S.true
                 self._symbols = dict()
 
             self.iterate_over_plug(instance, master_output, odc_info)
+        if iter >= len(ODCWalker.iter_rep):
+            ODCWalker.iter_rep += [0] * (1 + iter - (len(ODCWalker.iter_rep)))
+        ODCWalker.iter_rep[iter] += 1

--- a/cumulus/src/plugins/odc/ODCWalker.py
+++ b/cumulus/src/plugins/odc/ODCWalker.py
@@ -1,0 +1,161 @@
+# This file is part of the Coriolis Software.
+# Copyright (c) Sorbonne Université 2019-2023, All Rights Reserved
+#
+# +-----------------------------------------------------------------+
+# |                   C O R I O L I S                               |
+# |      C u m u l u s  -  P y t h o n   T o o l s                  |
+# |                                                                 |
+# |  Author      :                              Hippolyte MELICA    |
+# |  E-mail      :   hippolyte.melica@etu.sorbonne-universite.fr    |
+# | =============================================================== |
+# |  Python      :   "./plugins/odc/ODCWalker.py"                   |
+# +-----------------------------------------------------------------+
+
+from queue import LifoQueue
+
+from coriolis.Hurricane import Net, Plug
+from sympy import And, S, Symbol
+
+from .CellODCCache import CellODCCache
+from .FFDatabase import FFDatabase
+
+
+def getSymbolsMap(instance):
+    ret = {}
+    for plug in instance.getPlugs():
+        net = plug.getNet()
+        master_net = plug.getMasterNet()
+        if net is None:
+            continue
+        ret[master_net.getName()] = Symbol(net.getName(), boolean=True)
+    return ret
+
+
+def replaceSymbols(expr, correspondance):
+    ret = expr
+    ret = ret.subs(correspondance)
+    return ret
+
+
+class ODCWalker:
+    walker_number: int = 0
+    iter_count = 0
+
+    def __init__(
+        self,
+        net: Net = None,
+        todo: LifoQueue = None,
+        results: FFDatabase = None,
+        cache: CellODCCache = None,
+        other=None,
+        from_plug=False,
+        plug: Plug = None,
+        function=S.true,
+    ):
+        ODCWalker.walker_number += 1
+
+        if net is None and plug is None:
+            raise AttributeError
+        if other is None:
+            if cache is None or results is None:
+                print("[ERROR] Can not build walker without cache or results.")
+                raise AttributeError
+            self._cache = cache
+            self._from_plug = from_plug
+            self._function = S.true
+            self._net = net
+            self._plug = plug
+            self._results = results
+            self._symbols: dict[str, S] = {}
+            self._todo = todo
+        else:  # we need to do a deep copy because this is a child of another walker.
+            self._cache = other._cache  # not a copy
+            self._from_plug = from_plug
+            self._function = And(function, other._function)
+            self._net = net
+            self._plug = plug
+            self._results = other._results  # not a copy
+            self._symbols: dict[str, S] = other._symbols
+            self._todo = other._todo  # not a copy
+
+    def fork(self, net: Net = None, plug: Plug = None, function=S.true):
+        if net:
+            self._todo.put(ODCWalker(other=self, net=net, function=function))
+        elif plug:
+            self._todo.put(ODCWalker(other=self, plug=plug, from_plug=True, function=function))
+        else:
+            print("[ERROR] Calling fork for ODCWalker with no args")
+            raise AttributeError
+
+    def iterate_over_net(self):
+        net = self._net
+        first_plug = True
+        self._plug = None
+        for plug in net.getPlugs():
+            master_net = plug.getMasterNet()
+            if master_net.getDirection() != Net.Direction.OUT:
+                continue
+            if plug is None:  # end of path, no instance means external net
+                continue
+            if first_plug:
+                self._plug = plug
+                first_plug = False
+            else:
+                self.fork(plug=plug)
+
+    def iterate_over_plug(self, instance, master_output, odc_info):
+        # Getting out of cell
+        first = True
+        self._net = None
+        new_function = None
+        net_map = getSymbolsMap(instance)
+        for plug in instance.getPlugs():  # should use list in odc_info
+            net = plug.getNet()
+            master_net = plug.getMasterNet()
+            if master_net.getDirection() != Net.Direction.IN or master_net.isSupply() or master_net.isClock():
+                continue
+            if master_net.getName() not in odc_info._observability[master_output.getName()]:  # if pin is not observable
+                continue  # steering pins are not observable
+            if first:
+                if odc_info.isSteering:
+                    ext_expr = replaceSymbols(
+                        odc_info._observability[master_output.getName()][master_net.getName()], net_map
+                    )
+                    new_function = And(self._function, ext_expr)
+                self._net = net
+                first = False
+            else:
+                function = S.true
+                if odc_info.isSteering:
+                    ext_expr = replaceSymbols(
+                        odc_info._observability[master_output.getName()][master_net.getName()], net_map
+                    )
+                    function = ext_expr
+                self.fork(net=net, function=function)
+        if new_function is not None:
+            self._function = new_function
+
+    def run(self):
+        while self._plug is not None or self._net is not None:
+            ODCWalker.iter_count += 1
+            if not self._from_plug:
+                self.iterate_over_net()
+                if self._plug is None:  # no plugs were found
+                    return
+            else:
+                self._from_plug = False
+            # All plugs explored
+            instance = self._plug.getInstance()
+            master_output = self._plug.getMasterNet()
+            self._plug = None
+            odc_info = self._cache[instance]
+
+            # Encounters FF
+            if odc_info.isFlipflop:
+                stop_there = self._results.addNewFF(instance, odc_info, self._function)
+                if stop_there:
+                    return  # A younger mike did already leave from there
+                self._function = S.true
+                self._symbols = dict()
+
+            self.iterate_over_plug(instance, master_output, odc_info)

--- a/cumulus/src/plugins/odc/ODCWalker.py
+++ b/cumulus/src/plugins/odc/ODCWalker.py
@@ -67,7 +67,6 @@ class ODCWalker:
             self._net = net
             self._plug = plug
             self._results = results
-            self._symbols: dict[str, S] = {}
             self._todo = todo
         else:  # we need to do a deep copy because this is a child of another walker.
             self._cache = other._cache  # not a copy
@@ -76,7 +75,6 @@ class ODCWalker:
             self._net = net
             self._plug = plug
             self._results = other._results  # not a copy
-            self._symbols: dict[str, S] = other._symbols
             self._todo = other._todo  # not a copy
 
     def fork(self, net: Net = None, plug: Plug = None, function=S.true):
@@ -157,7 +155,6 @@ class ODCWalker:
                 if stop_there:
                     break  # A younger mike did already leave from there
                 self._function = S.true
-                self._symbols = dict()
 
             self.iterate_over_plug(instance, master_output, odc_info)
         if iter >= len(ODCWalker.iter_rep):

--- a/cumulus/src/plugins/odc/ODCWalker.py
+++ b/cumulus/src/plugins/odc/ODCWalker.py
@@ -68,6 +68,7 @@ class ODCWalker:
             self._plug = plug
             self._results = results
             self._todo = todo
+            self._path = list()
         else:  # we need to do a deep copy because this is a child of another walker.
             self._cache = other._cache  # not a copy
             self._from_plug = from_plug
@@ -76,6 +77,7 @@ class ODCWalker:
             self._plug = plug
             self._results = other._results  # not a copy
             self._todo = other._todo  # not a copy
+            self._path = list(other._path)
 
     def fork(self, net: Net = None, plug: Plug = None, function=S.true):
         if net:
@@ -159,10 +161,13 @@ class ODCWalker:
 
             # Encounters FF
             if odc_info.isFlipflop:
-                stop_there = self._results.addNewFF(instance, odc_info, self._function)
+                stop_there = self._results.addNewFF(instance, odc_info, self._function, self._path)
                 if stop_there:
                     break  # A younger mike did already leave from there
                 self._function = S.true
+                self._path = list()
+            else:
+                self._path.append(instance.getName())
 
             self.iterate_over_plug(instance, master_output, odc_info)
         if iter >= len(ODCWalker.iter_rep):

--- a/cumulus/src/plugins/odc/ODCWalker.py
+++ b/cumulus/src/plugins/odc/ODCWalker.py
@@ -113,6 +113,14 @@ class ODCWalker:
                 continue
             if master_net.getName() not in odc_info._observability[master_output.getName()]:  # if pin is not observable
                 continue
+            if (
+                self._function == S.true
+                and odc_info._observability[master_output.getName()][master_net.getName()] == S.true
+            ):
+                if net.getName() in self._results.nets_true:
+                    continue
+                else:
+                    self._results.nets_true.add(net.getName())
             if first:
                 if odc_info.isSteering:
                     ext_expr = replaceSymbols(

--- a/cumulus/src/plugins/odc/meson.build
+++ b/cumulus/src/plugins/odc/meson.build
@@ -1,0 +1,8 @@
+odc = files([
+  'CellODC.py',
+  'CellODCCache.py',
+  'ODCWalker.py',
+  'FFDatabase.py',
+  '__init__.py',
+  'odc.py',
+])

--- a/cumulus/src/plugins/odc/odc.py
+++ b/cumulus/src/plugins/odc/odc.py
@@ -1,0 +1,99 @@
+# This file is part of the Coriolis Software.
+# Copyright (c) Sorbonne Université 2019-2023, All Rights Reserved
+#
+# +-----------------------------------------------------------------+
+# |                   C O R I O L I S                               |
+# |      C u m u l u s  -  P y t h o n   T o o l s                  |
+# |                                                                 |
+# |  Author      :                              Hippolyte MELICA    |
+# |  E-mail      :   hippolyte.melica@etu.sorbonne-universite.fr    |
+# | =============================================================== |
+# |  Python      :   "./plugins/odc/odc.py"                         |
+# +-----------------------------------------------------------------+
+
+from collections import OrderedDict
+from datetime import datetime
+from queue import LifoQueue
+from threading import Event, Thread
+
+from coriolis.Hurricane import Cell, Net
+
+from .CellODCCache import CellODCCache
+from .FFDatabase import FFDatabase
+from .ODCWalker import ODCWalker
+
+
+class odc:
+    def __init__(self, circuit: Cell):
+        self._cell: Cell = circuit
+        self._todo: LifoQueue = LifoQueue()
+        self._db: FFDatabase = FFDatabase()
+        self._cache: CellODCCache = CellODCCache()
+        self._done: Event = Event()
+
+        for net in self._cell.getExternalNets():
+            if net.getDirection() == Net.Direction.OUT:
+                self._todo.put(ODCWalker(net=net, todo=self._todo, results=self._db, cache=self._cache))
+
+    def run_odc(self):
+        ODCWalker.walker_number = 0
+        ODCWalker.iter_count = 0
+        try:
+            while not self._todo.empty():
+                task = self._todo.get()
+                task.run()
+        except BaseException as e:
+            self._done.set()
+            raise e
+        self._done.set()
+
+    def computeODC(self, force_simplify=False):
+        started = datetime.now()
+        print(f"Starting at {str(started).split('.')[0]}")
+        runner = Thread(target=self.run_odc)
+        runner.start()
+        rf = 5  # refresh rate
+        prev_walker_number = 0
+        avg_walker_growth = []
+        prev_walker_alive = 0
+        avg_walker_alive = []
+        prev_iter_count = 0
+        avg_iter_speed = []
+        print(f"Stats (live, refresh every {rf}s) :")
+        while not self._done.is_set():
+            print(f"Elapsed time : {str(datetime.now() - started).split('.')[0]}")
+            walker_number = ODCWalker.walker_number
+            walker_growth = (walker_number - prev_walker_number) / rf
+            avg_walker_growth.append(walker_growth)
+            print(f"Walker created : {walker_number} ({walker_growth:+} walker/s)")
+            prev_walker_number = walker_number
+            walker_alive = self._todo.qsize()
+            avg_walker_alive.append(walker_alive)
+            print(f"Walker alive : {walker_alive} ({(walker_alive - prev_walker_alive) / rf:+} walker/s)")
+            prev_walker_alive = walker_alive
+            iter_count = ODCWalker.iter_count
+            iter_speed = (iter_count - prev_iter_count) / rf
+            avg_iter_speed.append(iter_speed)
+            print(f"Iterations : {iter_count} ({iter_speed:} iterations/s)")
+            prev_iter_count = iter_count
+            self._done.wait(timeout=rf)
+            print("\033[F\033[K" * 4, end="")
+        print("\033[F\033[K", end="")
+        runner.join()
+        print("Stats :")
+        print(f"  Walkers : {ODCWalker.walker_number}")
+        print(f"    avg. growth : {sum(avg_walker_growth) / len(avg_walker_growth):+.2f} walker/s")
+        print(f"    avg. alive  : {sum(avg_walker_alive) / len(avg_walker_alive):.2f} walker")
+        print(f"  Iterations : {ODCWalker.iter_count}")
+        print(f"    avg. speed  : {sum(avg_iter_speed) / len(avg_iter_speed):.2f} iteration/s")
+        if force_simplify:
+            self._db.processFuncs()
+        print("ODC done.")
+
+    def save_to_file(self, filename="odc_results.odc"):
+        if not self._done.is_set():
+            print("[ERROR] ODC was not calculated yet, can not save to file.")
+        results = OrderedDict(sorted(self._db.items(), key=lambda item: item[0]))
+        with open(filename, "w") as f:
+            for key, value in results.items():
+                f.write(f"{key}: {value}\n")

--- a/cumulus/src/plugins/odc/odc.py
+++ b/cumulus/src/plugins/odc/odc.py
@@ -47,45 +47,49 @@ class odc:
             raise e
         self._done.set()
 
-    def computeODC(self, force_simplify=False):
+    def computeODC(self, force_simplify=False, refresh_rate=2):
         started = datetime.now()
         print(f"Starting at {str(started).split('.')[0]}")
         runner = Thread(target=self.run_odc)
         runner.start()
-        rf = 5  # refresh rate
         prev_walker_number = 0
         avg_walker_growth = []
         prev_walker_alive = 0
         avg_walker_alive = []
         prev_iter_count = 0
         avg_iter_speed = []
-        print(f"Stats (live, refresh every {rf}s) :")
+        print(f"Stats (live, refresh every {refresh_rate}s) :")
         while not self._done.is_set():
             print(f"Elapsed time : {str(datetime.now() - started).split('.')[0]}")
             walker_number = ODCWalker.walker_number
-            walker_growth = (walker_number - prev_walker_number) / rf
+            walker_growth = (walker_number - prev_walker_number) / refresh_rate
             avg_walker_growth.append(walker_growth)
             print(f"Walker created : {walker_number} ({walker_growth:+} walker/s)")
             prev_walker_number = walker_number
             walker_alive = self._todo.qsize()
             avg_walker_alive.append(walker_alive)
-            print(f"Walker alive : {walker_alive} ({(walker_alive - prev_walker_alive) / rf:+} walker/s)")
+            print(f"Walker alive : {walker_alive} ({(walker_alive - prev_walker_alive) / refresh_rate:+} walker/s)")
             prev_walker_alive = walker_alive
             iter_count = ODCWalker.iter_count
-            iter_speed = (iter_count - prev_iter_count) / rf
+            iter_speed = (iter_count - prev_iter_count) / refresh_rate
             avg_iter_speed.append(iter_speed)
             print(f"Iterations : {iter_count} ({iter_speed:} iterations/s)")
             prev_iter_count = iter_count
-            self._done.wait(timeout=rf)
+            self._done.wait(timeout=refresh_rate)
             print("\033[F\033[K" * 4, end="")
         print("\033[F\033[K", end="")
         runner.join()
         print("Stats :")
+        print(f"  Elapsed time : {str(datetime.now() - started).split('.')[0]}")
         print(f"  Walkers : {ODCWalker.walker_number}")
         print(f"    avg. growth : {sum(avg_walker_growth) / len(avg_walker_growth):+.2f} walker/s")
         print(f"    avg. alive  : {sum(avg_walker_alive) / len(avg_walker_alive):.2f} walker")
         print(f"  Iterations : {ODCWalker.iter_count}")
         print(f"    avg. speed  : {sum(avg_iter_speed) / len(avg_iter_speed):.2f} iteration/s")
+        print(f"    it. per w.  : {ODCWalker.iter_count/ODCWalker.walker_number:.2f} iteration/walker")
+        print("Iteration repartition")
+        for index, count in enumerate(ODCWalker.iter_rep):
+            print(f"{index}: {count}")
         if force_simplify:
             self._db.processFuncs()
         print("ODC done.")

--- a/cumulus/src/plugins/odc/odc.py
+++ b/cumulus/src/plugins/odc/odc.py
@@ -92,10 +92,15 @@ class odc:
         print(f"    avg. speed  : {sum(avg_iter_speed) / len(avg_iter_speed):.2f} iteration/s")
         print(f"    it. per w.  : {ODCWalker.iter_count/ODCWalker.walker_number:.2f} iteration/walker")
         print(f"  Results: {len(self._db)} flip-flops")
-        activation = len([f for f in self._db.values() if f.function != S.true])
+        functions = [f for f in self._db.values() if f.function != S.true]
+        activation = len(functions)
         print(f"    With activation: {activation} flip-flops ({activation*100/len(self._db):.2f}%)")
         print(f"    Simplified: {self._db.opti} functions out of {activation} ({self._db.opti*100/activation:.2f}%)")
         print(f"    Variables removed: {self._db.variables_removed}")
+        nb_var = [len(f.function.atoms()) for f in functions]
+        print(f"    Avg. variables: {sum(nb_var)/len(nb_var):.2f}")
+        print(f"    Max. variables: {max(nb_var)}")
+        print(f"    Min. variables: {min(nb_var)}")
         # print("Iteration repartition")
         # for index, count in enumerate(ODCWalker.iter_rep):
         #     print(f"{index}: {count}")
@@ -108,4 +113,4 @@ class odc:
         with open(filename, "w") as f:
             for value in results.values():
                 f.write(f"{value.name}: {value.function}\n")
-                # f.write(f"{value.name}: {value.no_opti}\n\n")
+                f.write(f"{value.name}: {value.no_opti}\n\n")

--- a/cumulus/src/plugins/odc/odc.py
+++ b/cumulus/src/plugins/odc/odc.py
@@ -79,6 +79,9 @@ class odc:
             self._done.wait(timeout=refresh_rate)
             print("\033[F\033[K" * 4, end="")
         print("\033[F\033[K", end="")
+        print("Simplifying functions, could take some time...")
+        self._db.compute_functions()
+        print("\033[F\033[K", end="")
         runner.join()
         print("Stats :")
         print(f"  Elapsed time : {str(datetime.now() - started).split('.')[0]}")
@@ -91,6 +94,8 @@ class odc:
         print(f"  Results: {len(self._db)} flip-flops")
         activation = len([f for f in self._db.values() if f.function != S.true])
         print(f"    With activation: {activation} flip-flops ({activation*100/len(self._db):.2f}%)")
+        print(f"    Simplified: {self._db.opti} functions out of {activation} ({self._db.opti*100/activation:.2f}%)")
+        print(f"    Variables removed: {self._db.variables_removed}")
         # print("Iteration repartition")
         # for index, count in enumerate(ODCWalker.iter_rep):
         #     print(f"{index}: {count}")
@@ -103,3 +108,4 @@ class odc:
         with open(filename, "w") as f:
             for value in results.values():
                 f.write(f"{value.name}: {value.function}\n")
+                # f.write(f"{value.name}: {value.no_opti}\n\n")

--- a/cumulus/src/plugins/odc/odc.py
+++ b/cumulus/src/plugins/odc/odc.py
@@ -17,9 +17,10 @@ from queue import LifoQueue
 from threading import Event, Thread
 
 from coriolis.Hurricane import Cell, Net
+from sympy import S, simplify_logic
 
 from .CellODCCache import CellODCCache
-from .FFDatabase import FFDatabase
+from .FFDatabase import FFDatabase, optimize_FFEntry
 from .ODCWalker import ODCWalker
 
 
@@ -87,11 +88,12 @@ class odc:
         print(f"  Iterations : {ODCWalker.iter_count}")
         print(f"    avg. speed  : {sum(avg_iter_speed) / len(avg_iter_speed):.2f} iteration/s")
         print(f"    it. per w.  : {ODCWalker.iter_count/ODCWalker.walker_number:.2f} iteration/walker")
-        print("Iteration repartition")
-        for index, count in enumerate(ODCWalker.iter_rep):
-            print(f"{index}: {count}")
-        if force_simplify:
-            self._db.processFuncs()
+        print(f"  Results: {len(self._db)} flip-flops")
+        activation = len([f for f in self._db.values() if f.function != S.true])
+        print(f"    With activation: {activation} flip-flops ({activation*100/len(self._db):.2f}%)")
+        # print("Iteration repartition")
+        # for index, count in enumerate(ODCWalker.iter_rep):
+        #     print(f"{index}: {count}")
         print("ODC done.")
 
     def save_to_file(self, filename="odc_results.odc"):
@@ -99,5 +101,5 @@ class odc:
             print("[ERROR] ODC was not calculated yet, can not save to file.")
         results = OrderedDict(sorted(self._db.items(), key=lambda item: item[0]))
         with open(filename, "w") as f:
-            for key, value in results.items():
-                f.write(f"{key}: {value}\n")
+            for value in results.values():
+                f.write(f"{value.name}: {value.function}\n")

--- a/cumulus/src/plugins/odc/odc.py
+++ b/cumulus/src/plugins/odc/odc.py
@@ -25,12 +25,13 @@ from .ODCWalker import ODCWalker
 
 
 class odc:
-    def __init__(self, circuit: Cell):
+    def __init__(self, circuit: Cell, enable_estimate=True):
         self._cell: Cell = circuit
         self._todo: LifoQueue = LifoQueue()
-        self._db: FFDatabase = FFDatabase()
+        self._db: FFDatabase = FFDatabase(enable_estimate=enable_estimate)
         self._cache: CellODCCache = CellODCCache()
         self._done: Event = Event()
+        self._enable_estimate = enable_estimate
 
         for net in self._cell.getExternalNets():
             if net.getDirection() == Net.Direction.OUT:
@@ -39,6 +40,8 @@ class odc:
     def run_odc(self):
         ODCWalker.walker_number = 0
         ODCWalker.iter_count = 0
+        ODCWalker.iter_rep = list()
+        ODCWalker.path_id = 0
         try:
             while not self._todo.empty():
                 task = self._todo.get()
@@ -101,6 +104,8 @@ class odc:
         print(f"    Avg. variables: {sum(nb_var)/len(nb_var):.2f}")
         print(f"    Max. variables: {max(nb_var)}")
         print(f"    Min. variables: {min(nb_var)}")
+        if self._enable_estimate:
+            print(f"    Est. impact on cells: {self._db.compute_estimate()*100:.2f}%")
         # print("Iteration repartition")
         # for index, count in enumerate(ODCWalker.iter_rep):
         #     print(f"{index}: {count}")


### PR DESCRIPTION
Cette pull request ajoute la possibilité de calculer l'observabilité des cellules sur n'importe quel circuit.

## Usage

```python
# quelque part pendant l'initialisation
from coriolis.plugins import libertyParser
libertyParser.initLibertyLib("/path/to/liberty.lib")
```

```python
# quelque part dans le doDesign.py
from coriolis import CRL

cell_name = "picorv32"
cell = CRL.Blif.load(cell_name)

from coriolis.plugins.odc.odc import odc

odc_util = odc(cell, enable_estimate=True)
# enable_estimate is True by default

odc_util.computeODC()
odc_util.save_to_file(filename=f"{cell_name}.odc")
```

## Précisions

- `enable_estimate` permet d'activer l'estimation du nombre de cellules (non flip-flop) impactées par l'observabilité. Cette métrique pourrait donner une idée de  l'impact du clock gating sur le circuit, c'est à tester.
- le format de sortie de `save_to_file` est un fichier contenant sur chaque ligne un nom de flip-flop, puis la fonction d'observabilité de sa sortie, par exemple :

```
ff_1: wire_a | wire_b
```